### PR TITLE
make convertDnToAttributes public

### DIFF
--- a/core/src/main/java/org/ldaptive/DnParser.java
+++ b/core/src/main/java/org/ldaptive/DnParser.java
@@ -117,7 +117,7 @@ public final class DnParser
    *
    * @return  list of ldap attributes for each RDN
    */
-  protected static List<LdapAttribute> convertDnToAttributes(final String dn)
+  public static List<LdapAttribute> convertDnToAttributes(final String dn)
   {
     LOGGER.debug("parsing DN: {}", dn);
 


### PR DESCRIPTION
I'm working on implementing a library that abstracts out a nested LDAP object structure. This object abstraction needs access to a parsed DN to extract out the individual components.

It would be beneficial to utilize this RFC 4514 aware implementation without having to go through substring which gives back a String I would still need to parse or through getValue/getValues which discards useful structure information.
