### PR TITLE
Add schema support for an aggregate authenticator.

### DIFF
--- a/beans/src/main/java/org/ldaptive/beans/spring/NamespaceHandler.java
+++ b/beans/src/main/java/org/ldaptive/beans/spring/NamespaceHandler.java
@@ -2,6 +2,7 @@
 package org.ldaptive.beans.spring;
 
 import org.ldaptive.beans.spring.parser.ADAuthenticatorBeanDefinitionParser;
+import org.ldaptive.beans.spring.parser.AggregateAuthenticatorBeanDefinitionParser;
 import org.ldaptive.beans.spring.parser.AggregatePooledSearchExecutorBeanDefinitionParser;
 import org.ldaptive.beans.spring.parser.AggregateSearchExecutorBeanDefinitionParser;
 import org.ldaptive.beans.spring.parser.AnonSearchAuthenticatorBeanDefinitionParser;
@@ -36,6 +37,7 @@ public class NamespaceHandler extends NamespaceHandlerSupport
       new SaslBindSearchAuthenticatorBeanDefinitionParser());
     registerBeanDefinitionParser("direct-authenticator", new DirectAuthenticatorBeanDefinitionParser());
     registerBeanDefinitionParser("ad-authenticator", new ADAuthenticatorBeanDefinitionParser());
+    registerBeanDefinitionParser("aggregate-authenticator", new AggregateAuthenticatorBeanDefinitionParser());
     registerBeanDefinitionParser("pooled-connection-factory", new PooledConnectionFactoryBeanDefinitionParser());
     registerBeanDefinitionParser("connection-factory", new ConnectionFactoryBeanDefinitionParser());
     registerBeanDefinitionParser("connection-pool", new ConnectionPoolBeanDefinitionParser());

--- a/beans/src/main/java/org/ldaptive/beans/spring/parser/AbstractSearchAuthenticatorBeanDefinitionParser.java
+++ b/beans/src/main/java/org/ldaptive/beans/spring/parser/AbstractSearchAuthenticatorBeanDefinitionParser.java
@@ -50,6 +50,9 @@ public abstract class AbstractSearchAuthenticatorBeanDefinitionParser extends Ab
 
     final BeanDefinitionBuilder entryResolver = parseEntryResolver(element, connectionFactory);
     builder.addPropertyValue("entryResolver", entryResolver.getBeanDefinition());
+
+    setIfPresent(element, "returnAttributes", builder);
+    builder.addPropertyValue("resolveEntryOnFailure", element.getAttribute("resolveEntryOnFailure"));
   }
 
 

--- a/beans/src/main/java/org/ldaptive/beans/spring/parser/AggregateAuthenticatorBeanDefinitionParser.java
+++ b/beans/src/main/java/org/ldaptive/beans/spring/parser/AggregateAuthenticatorBeanDefinitionParser.java
@@ -1,0 +1,225 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.beans.spring.parser;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.ldaptive.auth.AggregateDnResolver;
+import org.ldaptive.auth.AuthenticationHandler;
+import org.ldaptive.auth.AuthenticationResponseHandler;
+import org.ldaptive.auth.Authenticator;
+import org.ldaptive.auth.DnResolver;
+import org.ldaptive.auth.EntryResolver;
+import org.springframework.beans.factory.BeanDefinitionStoreException;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.beans.factory.xml.BeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/**
+ * Parser for <pre>aggregate-authenticator</pre> elements.
+ *
+ * @author Middleware Services
+ */
+public class AggregateAuthenticatorBeanDefinitionParser
+  extends org.springframework.beans.factory.xml.AbstractBeanDefinitionParser
+{
+
+
+  @Override
+  protected String resolveId(
+    final Element element,
+    // CheckStyle:IllegalTypeCheck OFF
+    final AbstractBeanDefinition definition,
+    // CheckStyle:IllegalTypeCheck ON
+    final ParserContext parserContext)
+    throws BeanDefinitionStoreException
+  {
+    final String idAttrValue = element.getAttribute("id");
+    return StringUtils.hasText(idAttrValue) ? idAttrValue : "aggregate-authenticator";
+  }
+
+
+  @Override
+  protected AbstractBeanDefinition parseInternal(final Element element, final ParserContext context)
+  {
+    final BeanDefinitionBuilder factory = BeanDefinitionBuilder.rootBeanDefinition(
+      AggregateAuthenticatorFactoryBean.class);
+    final ManagedList<BeanDefinition> authenticators = new ManagedList<>();
+    for (Node child = element.getFirstChild(); child != null; child = child.getNextSibling()) {
+      BeanDefinitionParser parser = null;
+      if (child instanceof Element) {
+        switch (child.getLocalName()) {
+
+        case "anonymous-search-authenticator":
+          parser = new AnonSearchAuthenticatorBeanDefinitionParser();
+          break;
+
+        case "bind-search-authenticator":
+          parser = new BindSearchAuthenticatorBeanDefinitionParser();
+          break;
+
+        case "sasl-bind-search-authenticator":
+          parser = new SaslBindSearchAuthenticatorBeanDefinitionParser();
+          break;
+
+        case "direct-authenticator":
+          parser = new DirectAuthenticatorBeanDefinitionParser();
+          break;
+
+        case "ad-authenticator":
+          parser = new ADAuthenticatorBeanDefinitionParser();
+          break;
+
+        default:
+          throw new IllegalArgumentException("Unknown authenticator type: " + child.getLocalName());
+        }
+      }
+      if (parser != null) {
+        authenticators.add(parser.parse((Element) child, context));
+      }
+    }
+
+    factory.addPropertyValue("authenticators", authenticators);
+    factory.addPropertyValue("allowMultipleDns", element.getAttribute("allowMultipleDns"));
+    if (element.hasAttribute("returnAttributes")) {
+      factory.addPropertyValue("returnAttributes", element.getAttribute("returnAttributes"));
+    }
+    factory.addPropertyValue("resolveEntryOnFailure", element.getAttribute("resolveEntryOnFailure"));
+    return factory.getBeanDefinition();
+  }
+
+
+  /**
+   * Factory bean that creates an authenticator with an {@link AggregateDnResolver}.
+   */
+  protected static class AggregateAuthenticatorFactoryBean implements FactoryBean<Authenticator>
+  {
+
+    /** Authenticators to aggregate. */
+    private List<Authenticator> authenticators;
+
+    /** Value for {@link AggregateDnResolver#allowMultipleDns}. */
+    private boolean allowMultipleDns;
+
+    /** Value for {@link Authenticator#returnAttributes}. */
+    private String[] returnAttributes;
+
+    /** Value of {@link Authenticator#resolveEntryOnFailure}. */
+    private boolean resolveEntryOnFailure;
+
+
+    /**
+     * Sets the authenticators to aggregate.
+     *
+     * @param  auths  authenticators to aggregate
+     */
+    public void setAuthenticators(final List<Authenticator> auths)
+    {
+      authenticators = auths;
+    }
+
+
+    /**
+     * Sets whether the aggrgate authenticator will allow multiple DNs.
+     *
+     * @param  b  whether multiple DNs are allowed
+     */
+    public void setAllowMultipleDns(final boolean b)
+    {
+      allowMultipleDns = b;
+    }
+
+
+    /**
+     * Sets the return attributes.
+     *
+     * @param  attrs  return attributes
+     */
+    public void setReturnAttributes(final String... attrs)
+    {
+      returnAttributes = attrs;
+    }
+
+
+    /**
+     * Sets whether to execute the entry resolver on authentication failure.
+     *
+     * @param  b  whether to execute the entry resolver
+     */
+    public void setResolveEntryOnFailure(final boolean b)
+    {
+      resolveEntryOnFailure = b;
+    }
+
+
+    @Override
+    public Authenticator getObject() throws Exception
+    {
+      final Authenticator aggregateAuth = new Authenticator();
+      final Map<String, DnResolver> dnResolvers = new HashMap<>();
+      final Map<String, AuthenticationHandler> authHandlers = new HashMap<>();
+      final Map<String, EntryResolver> entryResolvers = new HashMap<>();
+      final Map<String, AuthenticationResponseHandler[]> responseHandlers = new HashMap<>();
+
+      int count = 0;
+      for (Authenticator auth : authenticators) {
+        final String id = String.format("%s-%s", auth.hashCode(), String.valueOf(count++));
+        dnResolvers.put(id, auth.getDnResolver());
+        authHandlers.put(id, auth.getAuthenticationHandler());
+        if (auth.getEntryResolver() != null) {
+          entryResolvers.put(id, auth.getEntryResolver());
+        }
+        if (auth.getAuthenticationResponseHandlers() != null) {
+          responseHandlers.put(id, auth.getAuthenticationResponseHandlers());
+        }
+      }
+
+      final AggregateDnResolver dnResolver = new AggregateDnResolver();
+      dnResolver.setAllowMultipleDns(allowMultipleDns);
+      dnResolver.setDnResolvers(dnResolvers);
+      aggregateAuth.setDnResolver(dnResolver);
+
+      final AggregateDnResolver.AuthenticationHandler authHandler = new AggregateDnResolver.AuthenticationHandler();
+      authHandler.setAuthenticationHandlers(authHandlers);
+      aggregateAuth.setAuthenticationHandler(authHandler);
+
+      if (!entryResolvers.isEmpty()) {
+        final AggregateDnResolver.EntryResolver entryResolver = new AggregateDnResolver.EntryResolver();
+        entryResolver.setEntryResolvers(entryResolvers);
+        aggregateAuth.setEntryResolver(entryResolver);
+      }
+
+      if (!responseHandlers.isEmpty()) {
+        final AggregateDnResolver.AuthenticationResponseHandler responseHandler =
+          new AggregateDnResolver.AuthenticationResponseHandler();
+        responseHandler.setAuthenticationResponseHandlers(responseHandlers);
+        aggregateAuth.setAuthenticationResponseHandlers(responseHandler);
+      }
+
+      aggregateAuth.setReturnAttributes(returnAttributes);
+      aggregateAuth.setResolveEntryOnFailure(resolveEntryOnFailure);
+      return aggregateAuth;
+    }
+
+
+    @Override
+    public Class<Authenticator> getObjectType()
+    {
+      return Authenticator.class;
+    }
+
+
+    @Override
+    public boolean isSingleton()
+    {
+      return true;
+    }
+  }
+}

--- a/beans/src/main/resources/org/ldaptive/beans/spring/spring-ext.xsd
+++ b/beans/src/main/resources/org/ldaptive/beans/spring/spring-ext.xsd
@@ -12,6 +12,7 @@
   <xsd:element name="sasl-bind-search-authenticator" type="saslBindSearchAuthenticatorType"/>
   <xsd:element name="direct-authenticator" type="directAuthenticatorType"/>
   <xsd:element name="ad-authenticator" type="adAuthenticatorType"/>
+  <xsd:element name="aggregate-authenticator" type="aggregateAuthenticatorType"/>
   <xsd:element name="pooled-connection-factory" type="pooledConnectionFactoryType"/>
   <xsd:element name="connection-factory" type="connectionFactoryType"/>
   <xsd:element name="connection-pool" type="connectionPoolType"/>
@@ -80,6 +81,19 @@
     </xsd:complexContent>
   </xsd:complexType>
 
+  <xsd:complexType name="aggregateAuthenticatorType">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="anonymous-search-authenticator" type="anonymousSearchAuthenticatorType"/>
+      <xsd:element name="bind-search-authenticator" type="bindSearchAuthenticatorType"/>
+      <xsd:element name="sasl-bind-search-authenticator" type="saslBindSearchAuthenticatorType"/>
+      <xsd:element name="direct-authenticator" type="directAuthenticatorType"/>
+      <xsd:element name="ad-authenticator" type="adAuthenticatorType"/>
+    </xsd:choice>
+    <xsd:attribute name="returnAttributes" type="xsd:string" use="optional"/>
+    <xsd:attribute name="allowMultipleDns" type="xsd:string" use="optional" default="false"/>
+    <xsd:attribute name="resolveEntryOnFailure" type="xsd:string" use="optional" default="false"/>
+  </xsd:complexType>
+
   <xsd:complexType name="baseBindSearchAuthenticatorType">
     <xsd:complexContent>
       <xsd:extension base="baseSearchAuthenticatorType">
@@ -96,7 +110,9 @@
         <xsd:attribute name="baseDn" type="xsd:string" use="required"/>
         <xsd:attribute name="userFilter" type="xsd:string" use="required"/>
         <xsd:attribute name="subtreeSearch" type="xsd:string" use="optional" default="false"/>
+        <xsd:attribute name="returnAttributes" type="xsd:string" use="optional"/>
         <xsd:attribute name="allowMultipleDns" type="xsd:string" use="optional" default="false"/>
+        <xsd:attribute name="resolveEntryOnFailure" type="xsd:string" use="optional" default="false"/>
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>

--- a/core/src/main/java/org/ldaptive/auth/Authenticator.java
+++ b/core/src/main/java/org/ldaptive/auth/Authenticator.java
@@ -381,7 +381,11 @@ public class Authenticator
       if (entryResolver != null) {
         er = entryResolver;
       } else if (!ReturnAttributes.NONE.equalsAttributes(criteria.getAuthenticationRequest().getReturnAttributes())) {
-        er = new SearchEntryResolver();
+        if (dnResolver instanceof AggregateDnResolver) {
+          er = ((AggregateDnResolver) dnResolver).createEntryResolver(new SearchEntryResolver());
+        } else {
+          er = new SearchEntryResolver();
+        }
       } else {
         er = NOOP_RESOLVER;
       }

--- a/integration/src/test/java/org/ldaptive/auth/AuthenticatorTest.java
+++ b/integration/src/test/java/org/ldaptive/auth/AuthenticatorTest.java
@@ -810,20 +810,20 @@ public class AuthenticatorTest extends AbstractTest
     sr2.setUserFilter(sr1.getUserFilter());
     sr2.setUserFilterParameters(sr1.getUserFilterParameters());
 
-    final Map<String, DnResolver> resolvers = new HashMap<>();
-    resolvers.put("system1", sr1);
-    resolvers.put("system2", sr2);
+    final Map<String, DnResolver> dnResolvers = new HashMap<>();
+    dnResolvers.put("system1", sr1);
+    dnResolvers.put("system2", sr2);
 
-    final AggregateDnResolver resolver = new AggregateDnResolver(resolvers);
-    auth.setDnResolver(resolver);
+    final AggregateDnResolver dnResolver = new AggregateDnResolver(dnResolvers);
+    auth.setDnResolver(dnResolver);
 
-    final Map<String, AuthenticationHandler> handlers = new HashMap<>();
-    handlers.put("system1", auth.getAuthenticationHandler());
-    handlers.put("system2", auth.getAuthenticationHandler());
+    final Map<String, AuthenticationHandler> authHandlers = new HashMap<>();
+    authHandlers.put("system1", auth.getAuthenticationHandler());
+    authHandlers.put("system2", auth.getAuthenticationHandler());
 
-    final AggregateDnResolver.AuthenticationHandler handler = new AggregateDnResolver.AuthenticationHandler();
-    handler.setAuthenticationHandlers(handlers);
-    auth.setAuthenticationHandler(handler);
+    final AggregateDnResolver.AuthenticationHandler authHandler = new AggregateDnResolver.AuthenticationHandler();
+    authHandler.setAuthenticationHandlers(authHandlers);
+    auth.setAuthenticationHandler(authHandler);
 
     // test invalid user
     AuthenticationResponse response = auth.authenticate(
@@ -840,7 +840,7 @@ public class AuthenticatorTest extends AbstractTest
     } catch (Exception e) {
       AssertJUnit.assertEquals(LdapException.class, e.getClass());
     }
-    resolver.setAllowMultipleDns(true);
+    dnResolver.setAllowMultipleDns(true);
 
     // test failed auth with return attributes
     response = auth.authenticate(

--- a/integration/src/test/resources/spring-ext-context.xml
+++ b/integration/src/test/resources/spring-ext-context.xml
@@ -207,4 +207,36 @@
     keyStoreAliases="${ldap.keyStoreAliases}"
   />
 
+  <ldaptive:aggregate-authenticator>
+    <ldaptive:anonymous-search-authenticator
+      ldapUrl="${ldap.url}"
+      trustCertificates="classpath:/ldaptive.trust.crt"
+      baseDn="${ldap.baseDn}"
+      userFilter="(mail={user})"
+      connectTimeout="${ldap.connectTimeout}"
+      useStartTLS="${ldap.useStartTLS}"
+      blockWaitTime="${ldap.pool.blockWaitTime}"
+      maxPoolSize="${ldap.pool.maxSize}"
+      minPoolSize="${ldap.pool.minSize}"
+    />
+    <ldaptive:bind-search-authenticator
+      ldapUrl="${ldap.url}"
+      trustStore="classpath:/ldaptive.truststore"
+      trustStorePassword="changeit"
+      trustStoreType="BKS"
+      baseDn="${ldap.baseDn}"
+      userFilter="(mail={user})"
+      bindDn="${ldap.bindDn}"
+      bindCredential="${ldap.bindCredential}"
+      resolveEntryWithBindCredentials="true"
+      connectTimeout="${ldap.connectTimeout}"
+      useStartTLS="${ldap.useStartTLS}"
+      blockWaitTime="${ldap.pool.blockWaitTime}"
+      maxPoolSize="${ldap.pool.maxSize}"
+      minPoolSize="${ldap.pool.minSize}">
+      <ldaptive:authentication-response-handler>
+        <ldaptive:password-policy-handler/>
+      </ldaptive:authentication-response-handler>
+    </ldaptive:bind-search-authenticator>
+  </ldaptive:aggregate-authenticator>
 </beans>


### PR DESCRIPTION
Update schema to allow for nesting authenticators.
Add entry resolvers and auth response handlers to the AggregateDnResolver implementation.
Update Authenticator to configure the entry resolver properly for an AggregateDnResolver.
Also added support for the returnAttributes and resolveEntryOnFailure properties on authenticators.
Fixes #102.