### PR TITLE
Use LdapName instead of CompositeName for DN.

### DIFF
--- a/core/src/main/java/org/ldaptive/provider/jndi/JndiConnection.java
+++ b/core/src/main/java/org/ldaptive/provider/jndi/JndiConnection.java
@@ -1036,21 +1036,21 @@ public class JndiConnection implements ProviderConnection
     protected String formatDn(final SearchResult sr, final String baseDn)
       throws NamingException
     {
-      StringBuilder fqName;
+      String fqName;
       if (sr.isRelative()) {
         logger.trace("formatting relative dn '{}'", sr.getNameInNamespace());
-        fqName = new StringBuilder(readCompositeName(sr.getNameInNamespace()));
+        final LdapName lname = new LdapName(sr.getNameInNamespace());
+        fqName = lname.toString();
       } else {
         logger.trace("formatting non-relative dn '{}'", sr.getName());
         if (config.getRemoveDnUrls()) {
-          fqName = new StringBuilder(readCompositeName(URI.create(sr.getName()).getPath().substring(1)));
+          fqName = readCompositeName(URI.create(sr.getName()).getPath().substring(1));
         } else {
-          fqName = new StringBuilder(readCompositeName(sr.getName()));
+          fqName = readCompositeName(sr.getName());
         }
       }
-      final String newDn = fqName.toString();
-      logger.trace("formatted dn '{}'", newDn);
-      return newDn;
+      logger.trace("formatted dn '{}'", fqName);
+      return fqName;
     }
 
 

--- a/integration/src/test/java/org/ldaptive/AbstractTest.java
+++ b/integration/src/test/java/org/ldaptive/AbstractTest.java
@@ -104,8 +104,8 @@ public abstract class AbstractTest
   {
     final CompareOperation compare = new CompareOperation(conn);
     final LdapAttribute la = new LdapAttribute();
-    la.setName(entry.getDn().split(",ou=")[0].split("=", 2)[0]);
-    la.addStringValue(entry.getDn().split(",ou=")[0].split("=", 2)[1].replaceAll("\\\\", ""));
+    la.setName("CN");
+    la.addStringValue(DnParser.getValue(entry.getDn(), "CN"));
     try {
       return compare.execute(new CompareRequest(entry.getDn(), la)).getResult();
     } catch (LdapException e) {

--- a/integration/src/test/resources/org/ldaptive/specialChars-3.ldif
+++ b/integration/src/test/resources/org/ldaptive/specialChars-3.ldif
@@ -1,0 +1,10 @@
+dn: cn=Test\\User,${ldapBaseDn}
+cn: Test\User
+givenName: Test
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+sn: User
+uid: 17895
+userPassword: {SHA}rfKc0oug83hbYSYg8IiuVsQZ8Wk=

--- a/integration/src/test/testng/testng.xml
+++ b/integration/src/test/testng/testng.xml
@@ -93,6 +93,8 @@
              value="/org/ldaptive/specialChars.ldif"/>
   <parameter name="createSpecialCharsEntry2"
              value="/org/ldaptive/specialChars-2.ldif"/>
+  <parameter name="createSpecialCharsEntry3"
+             value="/org/ldaptive/specialChars-3.ldif"/>
 
   <parameter name="multipleLdifResultsIn"
              value="/org/ldaptive/multipleEntriesIn.ldif"/>
@@ -374,8 +376,10 @@
   <parameter name="authenticateResults"
              value="/org/ldaptive/searchResults-6.ldif"/>
 
-  <parameter name="authenticateSpecialCharsUser" value="17894"/>
-  <parameter name="authenticateSpecialCharsCredential" value="password17894"/>
+  <parameter name="authenticateSpecialCharsUser2" value="17894"/>
+  <parameter name="authenticateSpecialCharsCredential2" value="password17894"/>
+  <parameter name="authenticateSpecialCharsUser3" value="17895"/>
+  <parameter name="authenticateSpecialCharsCredential3" value="password17895"/>
 
   <parameter name="digestMd5User" value="test3@vt.edu"/>
   <parameter name="digestMd5Credential" value="password"/>


### PR DESCRIPTION
Remove use of StringBuilder, since no strings were being built.
Add unit test for escaped backslash.

See #119 