### PR TITLE
Remove threadlocal after use.

### DIFF
--- a/core/src/main/java/org/ldaptive/provider/jndi/JndiConnectionFactory.java
+++ b/core/src/main/java/org/ldaptive/provider/jndi/JndiConnectionFactory.java
@@ -53,7 +53,6 @@ public class JndiConnectionFactory extends AbstractProviderConnectionFactory<Jnd
     if (ThreadLocalTLSSocketFactory.class.getName().equals(environment.get(JndiProvider.SOCKET_FACTORY))) {
       final ThreadLocalTLSSocketFactory sf = new ThreadLocalTLSSocketFactory();
       threadLocalSslConfig = sf.getSslConfig();
-      sf.removeSslConfig();
     }
   }
 

--- a/core/src/main/java/org/ldaptive/provider/jndi/JndiConnectionFactory.java
+++ b/core/src/main/java/org/ldaptive/provider/jndi/JndiConnectionFactory.java
@@ -51,7 +51,9 @@ public class JndiConnectionFactory extends AbstractProviderConnectionFactory<Jnd
     environment = Collections.unmodifiableMap(env);
     classLoader = cl;
     if (ThreadLocalTLSSocketFactory.class.getName().equals(environment.get(JndiProvider.SOCKET_FACTORY))) {
-      threadLocalSslConfig = new ThreadLocalTLSSocketFactory().getSslConfig();
+      final ThreadLocalTLSSocketFactory sf = new ThreadLocalTLSSocketFactory();
+      threadLocalSslConfig = sf.getSslConfig();
+      sf.removeSslConfig();
     }
   }
 
@@ -60,11 +62,12 @@ public class JndiConnectionFactory extends AbstractProviderConnectionFactory<Jnd
   protected JndiConnection createInternal(final String url)
     throws LdapException
   {
+    ThreadLocalTLSSocketFactory threadLocalTLSSocketFactory = null;
     if (
       threadLocalSslConfig != null &&
         ThreadLocalTLSSocketFactory.class.getName().equals(environment.get(JndiProvider.SOCKET_FACTORY))) {
-      final ThreadLocalTLSSocketFactory sf = new ThreadLocalTLSSocketFactory();
-      sf.setSslConfig(threadLocalSslConfig);
+      threadLocalTLSSocketFactory = new ThreadLocalTLSSocketFactory();
+      threadLocalTLSSocketFactory.setSslConfig(threadLocalSslConfig);
     }
 
     // CheckStyle:IllegalType OFF
@@ -88,6 +91,10 @@ public class JndiConnectionFactory extends AbstractProviderConnectionFactory<Jnd
       }
     } catch (NamingException e) {
       throw new ConnectionException(e, NamingExceptionUtils.getResultCode(e.getClass()));
+    } finally {
+      if (threadLocalTLSSocketFactory != null) {
+        threadLocalTLSSocketFactory.removeSslConfig();
+      }
     }
     return conn;
   }

--- a/core/src/main/java/org/ldaptive/ssl/ThreadLocalTLSSocketFactory.java
+++ b/core/src/main/java/org/ldaptive/ssl/ThreadLocalTLSSocketFactory.java
@@ -33,6 +33,15 @@ public class ThreadLocalTLSSocketFactory extends TLSSocketFactory
 
 
   /**
+   * Removes the ssl config from the current thread-local value.
+   */
+  public void removeSslConfig()
+  {
+    THREAD_LOCAL_SSL_CONFIG.remove();
+  }
+
+
+  /**
    * This returns the default SSL socket factory.
    *
    * @return  socket factory


### PR DESCRIPTION
Update the socket factory API to allow removal of the thread local.
Update jndi connection factory to remove thread locals.
See #136.