### PR TITLE
Encode cntrl chars in response message.

### DIFF
--- a/core/src/main/java/org/ldaptive/LdapUtils.java
+++ b/core/src/main/java/org/ldaptive/LdapUtils.java
@@ -13,6 +13,7 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 import java.util.Queue;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.ldaptive.io.Hex;
 
@@ -42,6 +43,9 @@ public final class LdapUtils
   private static final Pattern IPV6_HEX_COMPRESSED_PATTERN = Pattern.compile(
     "^((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)::" +
     "((?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4})*)?)$");
+
+  /** Pattern that matches control characters. */
+  private static final Pattern CNTRL_PATTERN = Pattern.compile("\\p{Cntrl}");
 
   /** Prefix used to indicate a classpath resource. */
   private static final String CLASSPATH_PREFIX = "classpath:";
@@ -192,6 +196,37 @@ public final class LdapUtils
       }
     }
     return sb.toString();
+  }
+
+
+  /**
+   * Converts all characters <= 0x1F and 0x7F to percent encoded hex.
+   *
+   * @param  value  to encode control characters in
+   *
+   * @return  string with percent encoded hex characters
+   */
+  public static String percentEncodeControlChars(final String value)
+  {
+    if (value != null) {
+      final Matcher m = CNTRL_PATTERN.matcher(value);
+      if (m.find()) {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+          final char ch = value.charAt(i);
+          // CheckStyle:MagicNumber OFF
+          if (ch <= 0x1F || ch == 0x7F) {
+            sb.append("%");
+            sb.append(hexEncode(new byte[] {(byte) (ch & 0x7F)}));
+          } else {
+            sb.append(ch);
+          }
+          // CheckStyle:MagicNumber ON
+        }
+        return sb.toString();
+      }
+    }
+    return value;
   }
 
 

--- a/core/src/main/java/org/ldaptive/Response.java
+++ b/core/src/main/java/org/ldaptive/Response.java
@@ -14,6 +14,22 @@ import org.ldaptive.control.ResponseControl;
 public class Response<T> implements ResponseMessage
 {
 
+  /** Property to configure the encoding of control characters in the response message. */
+  public static final String ENCODE_CNTRL_CHARS = "org.ldaptive.response.encodeCntrlChars";
+
+  /** Whether to encode control characters. */
+  protected static boolean encodeCntrlChars;
+
+  /**
+   * statically initialize encoding of control characters.
+   */
+  static {
+    final String ecc = System.getProperty(ENCODE_CNTRL_CHARS);
+    if (ecc != null) {
+      encodeCntrlChars = Boolean.valueOf(ecc);
+    }
+  }
+
   /** Operation response. */
   private final T result;
 
@@ -178,7 +194,7 @@ public class Response<T> implements ResponseMessage
         hashCode(),
         result,
         resultCode,
-        message,
+        encodeCntrlChars ? LdapUtils.percentEncodeControlChars(message) : message,
         matchedDn,
         Arrays.toString(responseControls),
         Arrays.toString(referralURLs),

--- a/core/src/main/java/org/ldaptive/auth/AuthenticationHandlerResponse.java
+++ b/core/src/main/java/org/ldaptive/auth/AuthenticationHandlerResponse.java
@@ -3,6 +3,7 @@ package org.ldaptive.auth;
 
 import java.util.Arrays;
 import org.ldaptive.Connection;
+import org.ldaptive.LdapUtils;
 import org.ldaptive.Response;
 import org.ldaptive.ResultCode;
 import org.ldaptive.control.ResponseControl;
@@ -91,14 +92,13 @@ public class AuthenticationHandlerResponse extends Response<Boolean>
   {
     return
       String.format(
-        "[%s@%d::connection=%s, result=%s, resultCode=%s, message=%s, " +
-        "controls=%s]",
+        "[%s@%d::connection=%s, result=%s, resultCode=%s, message=%s, controls=%s]",
         getClass().getName(),
         hashCode(),
         connection,
         getResult(),
         getResultCode(),
-        getMessage(),
+        encodeCntrlChars ? LdapUtils.percentEncodeControlChars(getMessage()) : getMessage(),
         Arrays.toString(getControls()));
   }
 }

--- a/core/src/main/java/org/ldaptive/auth/AuthenticationResponse.java
+++ b/core/src/main/java/org/ldaptive/auth/AuthenticationResponse.java
@@ -3,6 +3,7 @@ package org.ldaptive.auth;
 
 import java.util.Arrays;
 import org.ldaptive.LdapEntry;
+import org.ldaptive.LdapUtils;
 import org.ldaptive.Response;
 import org.ldaptive.ResultCode;
 import org.ldaptive.control.ResponseControl;
@@ -169,7 +170,7 @@ public class AuthenticationResponse extends Response<Boolean>
         accountState,
         getResult(),
         getResultCode(),
-        getMessage(),
+        encodeCntrlChars ? LdapUtils.percentEncodeControlChars(getMessage()) : getMessage(),
         Arrays.toString(getControls()));
   }
 }

--- a/core/src/test/java/org/ldaptive/auth/ext/ActiveDirectoryAccountStateTest.java
+++ b/core/src/test/java/org/ldaptive/auth/ext/ActiveDirectoryAccountStateTest.java
@@ -35,6 +35,11 @@ public class ActiveDirectoryAccountStateTest
           ActiveDirectoryAccountState.Error.LOGON_FAILURE,
         },
         new Object[] {
+          "80090308: LdapErr: DSID-0C09042F, comment: " +
+            "AcceptSecurityContext error, data 52e, v2580\u0000",
+          ActiveDirectoryAccountState.Error.LOGON_FAILURE,
+        },
+        new Object[] {
           "80090308: LdapErr: DSID-0C09030B, comment: " +
             "AcceptSecurityContext error, data 530, v893",
           ActiveDirectoryAccountState.Error.INVALID_LOGON_HOURS,


### PR DESCRIPTION
Add property to control percent encoding of the message in Response#toString.
See #138