### PR TITLE
Use byte buffer limit when parsing tags.

### DIFF
--- a/core/src/main/java/org/ldaptive/asn1/AbstractDERType.java
+++ b/core/src/main/java/org/ldaptive/asn1/AbstractDERType.java
@@ -40,8 +40,12 @@ public abstract class AbstractDERType
   protected byte[] encode(final byte[]... items)
   {
     int itemLength = 0;
-    for (byte[] b : items) {
-      itemLength += b.length;
+    if (items != null) {
+      for (byte[] b : items) {
+        if (b != null) {
+          itemLength += b.length;
+        }
+      }
     }
 
     final byte[] lengthBytes;
@@ -66,8 +70,12 @@ public abstract class AbstractDERType
     for (byte b : lengthBytes) {
       encodedItem.put(b);
     }
-    for (byte[] b : items) {
-      encodedItem.put(b);
+    if (items != null) {
+      for (byte[] b : items) {
+        if (b != null) {
+          encodedItem.put(b);
+        }
+      }
     }
     return encodedItem.array();
   }

--- a/core/src/main/java/org/ldaptive/asn1/DERParser.java
+++ b/core/src/main/java/org/ldaptive/asn1/DERParser.java
@@ -132,15 +132,16 @@ public class DERParser
     if ((b & 0x80) == 0x80) {
       final int len = b & 0x7F;
       if (len > 0) {
+        final int limit = encoded.limit();
         encoded.limit(encoded.position() + len);
         length = IntegerType.decodeUnsigned(encoded).intValue();
-        encoded.limit(encoded.capacity());
+        encoded.limit(limit);
       }
     } else {
       length = b;
     }
+    // CheckStyle:MagicNumber ON
     return length;
-      // CheckStyle:MagicNumber ON
   }
 
 
@@ -171,6 +172,7 @@ public class DERParser
    */
   private void parseTag(final DERTag tag, final ByteBuffer encoded)
   {
+    final int limit = encoded.limit();
     final int end = readLength(encoded) + encoded.position();
     final int start = encoded.position();
 
@@ -187,7 +189,7 @@ public class DERParser
     if (tag.isConstructed()) {
       parseTags(encoded);
     }
-    encoded.position(end).limit(encoded.capacity());
+    encoded.limit(limit).position(end);
   }
 
 

--- a/core/src/main/java/org/ldaptive/asn1/NullType.java
+++ b/core/src/main/java/org/ldaptive/asn1/NullType.java
@@ -1,0 +1,29 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.asn1;
+
+/**
+ * Convenience type for a tag with a null value.
+ *
+ * @author  Middleware Services
+ */
+public class NullType extends AbstractDERType implements DEREncoder
+{
+
+
+  /**
+   * Creates a new null type.
+   *
+   * @param  tag  der tag associated with this type
+   */
+  public NullType(final DERTag tag)
+  {
+    super(tag);
+  }
+
+
+  @Override
+  public byte[] encode()
+  {
+    return encode((byte[]) null);
+  }
+}


### PR DESCRIPTION
Add support for null types.