### PR TITLE
MWOS-38 Load Testing

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -74,6 +74,13 @@
       <artifactId>spring-expression</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- JMeter Load Testing Dependencies -->
+    <dependency>
+      <groupId>org.apache.jmeter</groupId>
+      <artifactId>ApacheJMeter_java</artifactId>
+      <version>5.1.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -142,6 +149,24 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
+          <execution>
+            <id>copy-integration-jar-to-jmeter-ext</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/jmeter/lib/ext</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.build.directory}</directory>
+                  <includes>
+                    <include>${project.artifactId}-${project.version}-tests.jar</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
           <execution>
             <id>copy-testng</id>
             <phase>validate</phase>
@@ -217,6 +242,58 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.lazerycode.jmeter</groupId>
+        <artifactId>jmeter-maven-plugin</artifactId>
+        <version>2.9.0</version>
+        <executions>
+          <!-- Run JMeter tests -->
+          <execution>
+            <id>jmeter-tests</id>
+            <goals>
+              <goal>jmeter</goal>
+            </goals>
+          </execution>
+          <!-- Fail build on errors in test -->
+          <execution>
+            <id>jmeter-check-results</id>
+            <goals>
+              <goal>results</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <errorRateThresholdInPercent>1</errorRateThresholdInPercent>
+          <generateReports>true</generateReports>
+          <propertiesReportGenerator>
+            <jmeter.reportgenerator.overall_granularity>1000</jmeter.reportgenerator.overall_granularity>
+          </propertiesReportGenerator>
+          <propertiesJMeter>
+            <jmeter.save.saveservice.thread_counts>true</jmeter.save.saveservice.thread_counts>
+            <jmeter.reportgenerator.apdex_satisfied_threshold>100</jmeter.reportgenerator.apdex_satisfied_threshold>
+            <jmeter.reportgenerator.apdex_tolerated_threshold>200</jmeter.reportgenerator.apdex_tolerated_threshold>
+          </propertiesJMeter>
+          <propertiesUser>
+            <ldapUrl>ldap://ldap-test</ldapUrl>
+            <numSearchSingleUsers>20</numSearchSingleUsers>
+            <numSearchPooledUsers>20</numSearchPooledUsers>
+            <numSearchDefaultUsers>20</numSearchDefaultUsers>
+            <numAuthDefaultUsers>20</numAuthDefaultUsers>
+            <userRampUp>2</userRampUp>
+            <runDuration>5</runDuration>
+            <connMaxOps>5</connMaxOps>
+            <autoReconnect>false</autoReconnect>
+            <minPoolSize>10</minPoolSize>
+            <maxPoolSize>10</maxPoolSize>
+          </propertiesUser>
+          <jmeterExtensions>
+            <artifact>org.ldaptive:ldaptive:${project.version}</artifact>
+            <artifact>kg.apc:jmeter-plugins-graphs-vs:2.0</artifact>
+            <artifact>kg.apc:jmeter-plugins-graphs-composite:2.0</artifact>
+            <artifact>org.springframework:spring-core:jar:5.1.9.RELEASE</artifact>
+          </jmeterExtensions>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/integration/src/test/java/org/ldaptive/jmeter/sampler/AbstractAuthLoadSampler.java
+++ b/integration/src/test/java/org/ldaptive/jmeter/sampler/AbstractAuthLoadSampler.java
@@ -1,0 +1,54 @@
+/*
+  See LICENSE for licensing and NOTICE for copyright.
+*/
+package org.ldaptive.jmeter.sampler;
+
+import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
+import org.apache.jmeter.samplers.SampleResult;
+import org.ldaptive.Credential;
+import org.ldaptive.LdapException;
+import org.ldaptive.auth.AuthenticationRequest;
+import org.ldaptive.auth.AuthenticationResponse;
+import org.ldaptive.auth.Authenticator;
+import org.ldaptive.auth.SearchDnResolver;
+import org.ldaptive.auth.SimpleBindAuthenticationHandler;
+import org.ldaptive.jmeter.setup_teardown.TestPlanConfig;
+
+/**
+ * Base class for Authentication based load sampling. Implementations only need to provide the
+ * {@link org.ldaptive.ConnectionFactory} to be used.
+ */
+public abstract class AbstractAuthLoadSampler extends AbstractSampler {
+
+    @Override
+    public SampleResult runTest(final JavaSamplerContext context) {
+        super.runTest(context);
+        final String authBaseDn = TestPlanConfig.getProperties().baseDn();
+        final String bindFilter = TestPlanConfig.getProperties().bindFilter();
+        final String authUserId = TestPlanConfig.getProperties().authRequestId();
+        final String authUserCredential = TestPlanConfig.getProperties().bindCredential();
+        SearchDnResolver dnResolver = SearchDnResolver.builder()
+                .factory(connectionFactory())
+                .dn(authBaseDn)
+                .filter(bindFilter)
+                .build();
+        // Create and start the Sampler
+        final SampleResult sampleResult = new SampleResult();
+        sampleResult.sampleStart();
+        SimpleBindAuthenticationHandler authHandler = new SimpleBindAuthenticationHandler(connectionFactory());
+        Authenticator auth = new Authenticator(dnResolver, authHandler);
+        try {
+            AuthenticationResponse authResponse =
+                    auth.authenticate(new AuthenticationRequest(authUserId, new Credential(authUserCredential)));
+            if (authResponse.isSuccess()) {
+                successResult(sampleResult, authResponse.toString());
+            } else {
+                failedResult(sampleResult, "Authenticated failed");
+            }
+        } catch (LdapException e) {
+            logger.error("Unexpected exception occurred", e);
+            failedResult(sampleResult, e);
+        }
+        return sampleResult;
+    }
+}

--- a/integration/src/test/java/org/ldaptive/jmeter/sampler/AbstractSampler.java
+++ b/integration/src/test/java/org/ldaptive/jmeter/sampler/AbstractSampler.java
@@ -1,0 +1,138 @@
+/*
+  See LICENSE for licensing and NOTICE for copyright.
+*/
+package org.ldaptive.jmeter.sampler;
+
+import org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient;
+import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
+import org.apache.jmeter.samplers.SampleResult;
+import org.ldaptive.ConnectionFactory;
+import org.ldaptive.LdapEntry;
+import org.ldaptive.LdapException;
+import org.ldaptive.jmeter.setup_teardown.TestPlanConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract class that provides most of the setup for all {@link org.apache.jmeter.protocol.java.sampler.JavaSampler}
+ * test types.
+ */
+public abstract class AbstractSampler extends AbstractJavaSamplerClient {
+
+    /** Logger instance */
+    static final Logger logger = LoggerFactory.getLogger(AbstractSampler.class);
+
+    /**
+     * Default constructor.
+     *
+     * The Java Sampler uses the default constructor to instantiate an instance
+     * of the client class.
+     */
+    AbstractSampler() {
+        logger.debug(whoAmI() + "\tConstruct");
+    }
+
+    /**
+     * Do an initial check to ensure the global test configuration was successful in the
+     * {@link org.apache.jmeter.threads.SetupThreadGroup}. This is executed on the first iteration and will break out
+     * of all tests in a Thread Group if the ThreadGroup has been configured to stop tests on failure, which it should
+     * be.
+     */
+    @Override
+    public SampleResult runTest(final JavaSamplerContext context) {
+        if (context.getJMeterContext().getVariables().getIteration() == 1) {
+            final SampleResult sampleResult = new SampleResult();
+            sampleResult.sampleStart();
+            // Return sampler with failed status so we can break out of tests
+            if (!TestPlanConfig.isSetupSuccess()) {
+                setupFailedResult(sampleResult);
+                return sampleResult;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Update current SampleResult with failed response when test setup has failed.
+     *
+     * @param sampleResult SampleResult to update
+     */
+    private void setupFailedResult(final SampleResult sampleResult) {
+        failedResult(sampleResult, new LdapException("Setup failed. See log for more details"));
+    }
+
+    /**
+     * Update current SampleResult with success response.
+     *
+     * @param sampleResult SampleResult to update
+     * @param message The response body to add for a successful request.
+     */
+    void successResult(final SampleResult sampleResult, final String message) {
+        sampleResult.sampleEnd();
+        sampleResult.setResponseCodeOK();
+        sampleResult.setResponseMessageOK();
+        sampleResult.setSuccessful(true);
+        sampleResult.setResponseData(message, "UTF-8");
+    }
+    /**
+     * Update current SampleResult with success response and LdapEntry in body.
+     *
+     * @param sampleResult SampleResult to update
+     * @param entry The LdapEntry expected for a successful request.
+     */
+    void successResult(final SampleResult sampleResult, final LdapEntry entry) {
+        successResult(sampleResult, entry.toString());
+    }
+
+
+
+    /**
+     * Default failed SampleResult
+     *
+     * @param sampleResult SampleResult to update
+     */
+    private void failedResult(final SampleResult sampleResult) {
+        sampleResult.sampleEnd();
+        sampleResult.setResponseCode("5000");
+        sampleResult.setResponseMessage("Failed");
+        sampleResult.setSuccessful(false);
+    }
+
+    /**
+     * Update current SampleResult with failed response and exception message.
+     *
+     * @param sampleResult SampleResult to update
+     * @param ex The exception that occurred to cause the failure.
+     */
+    void failedResult(final SampleResult sampleResult, LdapException ex) {
+        failedResult(sampleResult);
+        sampleResult.setResponseData(ex.getMessage(), "UTF-8");
+    }
+
+    /**
+     * Update current SampleResult with failed response and provided message.
+     *
+     * @param sampleResult SampleResult to update
+     * @param message response message to include with failed result.
+     */
+    void failedResult(final SampleResult sampleResult, String message) {
+        failedResult(sampleResult);
+        sampleResult.setResponseData(message, "UTF-8");
+    }
+
+    /**
+     * Generate a String identifier of this test for debugging purposes.
+     *
+     * @return a String identifier for this test instance
+     */
+    public static String whoAmI() {
+        return Thread.currentThread().toString();
+    }
+
+    /**
+     * {@link ConnectionFactory} to be used for this thread group
+     *
+     * @return fully initialized factory that can be used for making requests to ldap.
+     */
+    public abstract ConnectionFactory connectionFactory();
+}

--- a/integration/src/test/java/org/ldaptive/jmeter/sampler/AbstractSearchLoadSampler.java
+++ b/integration/src/test/java/org/ldaptive/jmeter/sampler/AbstractSearchLoadSampler.java
@@ -1,0 +1,44 @@
+/*
+  See LICENSE for licensing and NOTICE for copyright.
+*/
+package org.ldaptive.jmeter.sampler;
+
+import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
+import org.apache.jmeter.samplers.SampleResult;
+import org.ldaptive.LdapEntry;
+import org.ldaptive.LdapException;
+import org.ldaptive.SearchOperation;
+import org.ldaptive.SearchResponse;
+import org.ldaptive.jmeter.setup_teardown.TestPlanConfig;
+
+/**
+ * Abstract of {@link AbstractSampler} that provides the implementation of
+ * {@link org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient#runTest(JavaSamplerContext)}
+ * specific to LDAP Search tests.
+ */
+public abstract class AbstractSearchLoadSampler extends AbstractSampler {
+
+
+    @Override
+    public SampleResult runTest(final JavaSamplerContext context) {
+        super.runTest(context);
+        final String baseDn = TestPlanConfig.getProperties().baseDn();
+        final String searchFilter = TestPlanConfig.getProperties().searchFilter();
+        final SearchOperation searchOperation = new SearchOperation(connectionFactory(), baseDn);
+        final SampleResult sampleResult = new SampleResult();
+        sampleResult.sampleStart();
+        try {
+            final SearchResponse searchResponse = searchOperation.execute(searchFilter);
+            final LdapEntry entry = searchResponse.getEntry();
+            if (entry != null) {
+                successResult(sampleResult, entry);
+            } else {
+                successResult(sampleResult, "Search request was successful");
+            }
+        } catch (LdapException e) {
+            logger.error("Unexpected exception occurred while performing search", e);
+            failedResult(sampleResult, e);
+        }
+        return sampleResult;
+    }
+}

--- a/integration/src/test/java/org/ldaptive/jmeter/sampler/DefaultConnectionAuthSampler.java
+++ b/integration/src/test/java/org/ldaptive/jmeter/sampler/DefaultConnectionAuthSampler.java
@@ -1,0 +1,19 @@
+/*
+  See LICENSE for licensing and NOTICE for copyright.
+*/
+package org.ldaptive.jmeter.sampler;
+
+import org.ldaptive.DefaultConnectionFactory;
+import org.ldaptive.jmeter.setup_teardown.TestPlanConfig;
+
+/**
+ * Fully implemented instance of {@link org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient} that uses
+ * a {@link org.ldaptive.DefaultConnectionFactory} to run LDAP Authentication tests in a multi-threaded environment.
+ */
+public class DefaultConnectionAuthSampler extends AbstractAuthLoadSampler {
+
+    @Override
+    public DefaultConnectionFactory connectionFactory() {
+        return TestPlanConfig.getAuthDefaultConnectionFactory();
+    }
+}

--- a/integration/src/test/java/org/ldaptive/jmeter/sampler/DefaultConnectionSearchSampler.java
+++ b/integration/src/test/java/org/ldaptive/jmeter/sampler/DefaultConnectionSearchSampler.java
@@ -1,0 +1,19 @@
+/*
+  See LICENSE for licensing and NOTICE for copyright.
+*/
+package org.ldaptive.jmeter.sampler;
+
+import org.ldaptive.DefaultConnectionFactory;
+import org.ldaptive.jmeter.setup_teardown.TestPlanConfig;
+
+/**
+ * Fully implemented instance of {@link org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient} that uses
+ * a {@link org.ldaptive.DefaultConnectionFactory} to run LDAP Search tests in a multi-threaded environment.
+ */
+public class DefaultConnectionSearchSampler extends AbstractSearchLoadSampler {
+
+    @Override
+    public DefaultConnectionFactory connectionFactory() {
+        return TestPlanConfig.getDefaultConnectionFactory();
+    }
+}

--- a/integration/src/test/java/org/ldaptive/jmeter/sampler/PooledConnectionSearchSampler.java
+++ b/integration/src/test/java/org/ldaptive/jmeter/sampler/PooledConnectionSearchSampler.java
@@ -1,0 +1,19 @@
+/*
+  See LICENSE for licensing and NOTICE for copyright.
+*/
+package org.ldaptive.jmeter.sampler;
+
+import org.ldaptive.PooledConnectionFactory;
+import org.ldaptive.jmeter.setup_teardown.TestPlanConfig;
+
+/**
+ * Fully implemented instance of {@link org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient} that uses
+ * a {@link org.ldaptive.PooledConnectionFactory} to run LDAP Search tests in a multi-threaded environment.
+ */
+public class PooledConnectionSearchSampler extends AbstractSearchLoadSampler {
+
+    @Override
+    public PooledConnectionFactory connectionFactory() {
+        return TestPlanConfig.getPooledConnectionFactory();
+    }
+}

--- a/integration/src/test/java/org/ldaptive/jmeter/sampler/SingleConnectionSearchSampler.java
+++ b/integration/src/test/java/org/ldaptive/jmeter/sampler/SingleConnectionSearchSampler.java
@@ -1,0 +1,19 @@
+/*
+  See LICENSE for licensing and NOTICE for copyright.
+*/
+package org.ldaptive.jmeter.sampler;
+
+import org.ldaptive.SingleConnectionFactory;
+import org.ldaptive.jmeter.setup_teardown.TestPlanConfig;
+
+/**
+ * Fully implemented instance of {@link org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient} that uses
+ * a {@link org.ldaptive.SingleConnectionFactory} to run LDAP Search tests in a multi-threaded environment.
+ */
+public class SingleConnectionSearchSampler extends AbstractSearchLoadSampler {
+
+    @Override
+    public SingleConnectionFactory connectionFactory() {
+        return TestPlanConfig.getSingleConnectionFactory();
+    }
+}

--- a/integration/src/test/java/org/ldaptive/jmeter/setup_teardown/JMeterRuntimeProperties.java
+++ b/integration/src/test/java/org/ldaptive/jmeter/setup_teardown/JMeterRuntimeProperties.java
@@ -1,0 +1,196 @@
+/*
+  See LICENSE for licensing and NOTICE for copyright.
+*/
+package org.ldaptive.jmeter.setup_teardown;
+
+import java.lang.reflect.Field;
+import java.util.Properties;
+import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
+import org.ldaptive.LdapException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Properties that can be manipulated for JMeter test executions.
+ */
+public final class JMeterRuntimeProperties {
+
+    private static final Logger logger = LoggerFactory.getLogger(JMeterRuntimeProperties.class);
+
+    /** LDAP URL used for JMeter tests */
+    private String ldapUrl;
+
+    /** Base DN */
+    private String baseDn;
+
+    /** DN for Bind operations */
+    private String bindDn;
+
+    /** Credential for testing Authentication */
+    private String bindCredential;
+
+    /** Filter for Search operation tests */
+    private String searchFilter;
+
+    /** Filter for Authentication operation tests */
+    private String bindFilter;
+
+    /** {@link org.ldaptive.auth.User} identifier for Authentication operation tests */
+    private String authRequestId;
+
+    /** Max number of netty concurrent operations */
+    private int nettyConnectionMaxOps;
+
+    /** Initial pool size for {@link org.ldaptive.PooledConnectionFactory} */
+    private int minPoolSize;
+
+    /** Maximum pool size for {@link org.ldaptive.PooledConnectionFactory} */
+    private int maxPoolSize;
+
+    /** {@link org.ldaptive.ConnectionConfig} autoReconnect */
+    private boolean autoReconnect;
+
+    /** {@link org.ldaptive.ConnectionConfig} useStartTls */
+    private boolean useStartTls;
+
+    /** Properties that are defined at ldaptive runtime. */
+    private Properties ldaptiveProps;
+    /**
+     * Properties that are either set in the JMeter TestPlan or that have been provided via command
+     * line arguments prefixed with -J flag.
+     */
+    private JavaSamplerContext samplerContext;
+
+    /**
+     * Private constructor.
+     * Instantiation must occur using {@link #JMeterRuntimeProperties(Properties, JavaSamplerContext)}
+     */
+    private JMeterRuntimeProperties() {}
+
+    /**
+     * Default constructor.
+     * Initialize all properties that are used by JMeter tests at startup
+     *
+     * @param props Properties that are defined at ldaptive (via docker-compose or command line args) runtime.
+     * @param context current JMeter context
+     */
+    public JMeterRuntimeProperties(final Properties props, final JavaSamplerContext context) throws LdapException {
+        ldaptiveProps = props;
+        samplerContext = context;
+        bindFilter = getPropValue("AUTH_FILTER", null);
+        authRequestId = getPropValue("AUTH_REQUEST_ID", null);
+        baseDn = getPropValue("BASE_DN", "org.ldaptive.baseDn");
+        bindCredential = getPropValue("BIND_CREDENTIAL", "org.ldaptive.bindCredential");
+        bindDn = getPropValue("BIND_DN", "org.ldaptive.bindDn");
+        autoReconnect = Boolean.parseBoolean(getPropValue("CONNECTION_AUTO_RECONNECT", null));
+        nettyConnectionMaxOps = Integer.parseInt(getPropValue("CONNECTION_MAX_OPS", null));
+        useStartTls = Boolean.parseBoolean(getPropValue("CONNECTION_USE_START_TLS", "org.ldaptive.useStartTLS"));
+        ldapUrl = getPropValue("LDAP_URL", "org.ldaptive.ldapUrl");
+        maxPoolSize = Integer.parseInt(getPropValue("MAX_POOL_SIZE", null));
+        minPoolSize = Integer.parseInt(getPropValue("MIN_POOL_SIZE", null));
+        searchFilter = getPropValue("SEARCH_FILTER", null);
+    }
+
+    public String ldapUrl() {
+        return ldapUrl;
+    }
+
+    public String baseDn() {
+        return baseDn;
+    }
+
+    public String bindDn() {
+        return bindDn;
+    }
+
+    public String bindCredential() {
+        return bindCredential;
+    }
+
+    public String searchFilter() {
+        return searchFilter;
+    }
+
+    public String bindFilter() {
+        return bindFilter;
+    }
+
+    public String authRequestId() {
+        return authRequestId;
+    }
+
+    public int nettyConnectionMaxOps() {
+        return nettyConnectionMaxOps;
+    }
+
+    public int minPoolSize() {
+        return minPoolSize;
+    }
+
+    public int maxPoolSize() {
+        return maxPoolSize;
+    }
+
+    public boolean autoReconnect() {
+        return autoReconnect;
+    }
+
+    public boolean useStartTls() {
+        return useStartTls;
+    }
+
+    /**
+     * Get property from either the samplerContext or ldaptiveProperties (props defined in ldap.properties file).
+     *
+     * @param jmeterVarName name defined in the TestPlan jmx file
+     * @param ldaptivePropName name defined in ldap.properties file
+     *
+     * @return property value
+     *
+     * @throws LdapException when the property is not found in either location. This should never happen and
+     * indicates there was an issue with wiring up property sources or the test plan.
+     */
+    private String getPropValue(final String jmeterVarName, final String ldaptivePropName) throws LdapException
+    {
+        final String jmeterVar = samplerContext.getJMeterVariables().get(jmeterVarName);
+        /*
+           The jmx file for these tests use the JMeter Property function for passing variables around. By default
+           this will return 1 if there isn't a default value provided in the jmx. Any props that don't have default
+           values should be give the value 'undefined'.
+           Any properties that need to be overridden should be done so via command line args with -J flag or under
+           <propertiesUser> in the plugin.
+        */
+        if (jmeterVar != null && !jmeterVar.equals("undefined")) {
+            return jmeterVar;
+        }
+        if (ldaptivePropName != null) {
+            final String ldaptiveProp = ldaptiveProps.getProperty(ldaptivePropName);
+            if (ldaptiveProp != null) {
+                return ldaptiveProp;
+            }
+        }
+        throw new LdapException(
+                String.format("Expected either %s or %s property at runtime but neither were found",
+                        jmeterVarName,
+                        ldaptivePropName == null ? "N/A" : ldaptivePropName
+                ));
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder details = new StringBuilder("Runtime Properties");
+        details.append(System.lineSeparator()).append("{").append(System.lineSeparator());
+        for (Field field : this.getClass().getDeclaredFields()) {
+            details.append("\t");
+            try {
+                details.append(field.getName()).append(" : ");
+                details.append(field.get(this));
+            } catch ( IllegalAccessException ex ) {
+                logger.error("Exception occurred while getting field data", ex);
+            }
+            details.append(System.lineSeparator());
+        }
+        details.append("}");
+        return details.toString();
+    }
+}

--- a/integration/src/test/java/org/ldaptive/jmeter/setup_teardown/SetupSampler.java
+++ b/integration/src/test/java/org/ldaptive/jmeter/setup_teardown/SetupSampler.java
@@ -1,0 +1,45 @@
+/*
+  See LICENSE for licensing and NOTICE for copyright.
+*/
+package org.ldaptive.jmeter.setup_teardown;
+
+import org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient;
+import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
+import org.apache.jmeter.samplers.SampleResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.ldaptive.jmeter.sampler.AbstractSampler.whoAmI;
+
+/**
+ * This class does the initial setup for the tests that will be shared among all {@link ThreadGroup}s in a
+ * {@link org.apache.jmeter.testelement.TestPlan}. Therefore, it MUST be the
+ * {@link org.apache.jmeter.protocol.java.sampler.JavaSamplerClient} assigned to the
+ * {@link org.apache.jmeter.threads.SetupThreadGroup} to help prevent multi-threading issues once the actual testing
+ * groups start executing their tests.
+ */
+public class SetupSampler extends AbstractJavaSamplerClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(SetupSampler.class);
+
+    @Override
+    public void setupTest(final JavaSamplerContext context) {
+        logger.info("Setting up global test config with: " + whoAmI());
+        TestPlanConfig.initConnections(TestPlanConfig.ConnectionType.ALL, context);
+        final ThreadGroupProperties threadGroupProperties = new ThreadGroupProperties(context);
+        final String testDetails =
+                "**** Current Test Parameters ****" +
+                        System.lineSeparator() +
+                        threadGroupProperties.threadGroupPlanDetails() +
+                        System.lineSeparator() +
+                        TestPlanConfig.getProperties().toString();
+        System.out.println(testDetails);
+    }
+
+    @Override
+    public SampleResult runTest(final JavaSamplerContext context) {
+        return null;
+    }
+
+
+}

--- a/integration/src/test/java/org/ldaptive/jmeter/setup_teardown/TeardownSampler.java
+++ b/integration/src/test/java/org/ldaptive/jmeter/setup_teardown/TeardownSampler.java
@@ -1,0 +1,25 @@
+/*
+  See LICENSE for licensing and NOTICE for copyright.
+*/
+package org.ldaptive.jmeter.setup_teardown;
+
+import org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient;
+import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
+import org.apache.jmeter.samplers.SampleResult;
+
+/**
+ * Sampler that must be attached to a {@link org.apache.jmeter.threads.PostThreadGroup}. All global teardown operations
+ * should occur there.
+ */
+public class TeardownSampler extends AbstractJavaSamplerClient {
+
+    @Override
+    public void teardownTest(final JavaSamplerContext context) {
+        TestPlanConfig.teardownConfiguration();
+    }
+
+    @Override
+    public SampleResult runTest(final JavaSamplerContext context) {
+        return null;
+    }
+}

--- a/integration/src/test/java/org/ldaptive/jmeter/setup_teardown/TestPlanConfig.java
+++ b/integration/src/test/java/org/ldaptive/jmeter/setup_teardown/TestPlanConfig.java
@@ -1,0 +1,462 @@
+/*
+  See LICENSE for licensing and NOTICE for copyright.
+*/
+package org.ldaptive.jmeter.setup_teardown;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Properties;
+import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
+import org.ldaptive.BindConnectionInitializer;
+import org.ldaptive.ConnectionConfig;
+import org.ldaptive.Credential;
+import org.ldaptive.DefaultConnectionFactory;
+import org.ldaptive.LdapException;
+import org.ldaptive.LdapURL;
+import org.ldaptive.LdapUtils;
+import org.ldaptive.PooledConnectionFactory;
+import org.ldaptive.SingleConnectionFactory;
+import org.ldaptive.pool.PoolConfig;
+import org.ldaptive.provider.netty.NettyConnection;
+import org.ldaptive.ssl.AllowAnyTrustManager;
+import org.ldaptive.ssl.SslConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Configuration that is required for all ThreadGroups in a TestPlan. This will be instantiated in a setupThreadGroup
+ * that will execute before all other ThreadGroups.
+ */
+public final class TestPlanConfig {
+
+    /** Logger instance */
+    private static final Logger logger = LoggerFactory.getLogger(TestPlanConfig.class);
+
+    /**
+     * Config to be used with connections factories that are doing LDAP search operations.
+     * This is shared across threads in a test plan.
+     */
+    private static ConnectionConfig searchConnectionConfig;
+
+    /**
+     * Config to be used with connections factories that are doing LDAP authentication operations.
+     * This is shared across threads in a test plan.
+     */
+    private static ConnectionConfig authConnectionConfig;
+
+    /**
+     * {@link SingleConnectionFactory} to be used for tests performing LDAP search operations.
+     * This is shared across threads in a test plan.
+     */
+    private static SingleConnectionFactory singleConnectionFactory;
+
+    /**
+     * {@link PooledConnectionFactory} to be used for tests performing LDAP search operations.
+     * This is shared across threads in a test plan.
+     */
+    private static PooledConnectionFactory pooledConnectionFactory;
+
+    /**
+     * {@link DefaultConnectionFactory} to be used for tests performing LDAP search operations.
+     * This is shared across threads in a test plan.
+     */
+    private static DefaultConnectionFactory defaultConnectionFactory;
+
+    /**
+     * {@link DefaultConnectionFactory} to be used for tests performing LDAP authentication operations.
+     * This is shared across threads in a test plan.
+     */
+    private static DefaultConnectionFactory authDefaultConnectionFactory;
+
+    /**
+     * Properties for JMeter Sampler tests that are partially loaded from runtime properties defined via docker-compose
+     */
+    private static JMeterRuntimeProperties properties;
+
+    /** Flag indicating whether the initial configuration for this test plan was successful. */
+    private static volatile boolean setupSuccess = false;
+
+    /** Default private constructor. All access should occur via static functions. */
+    private TestPlanConfig() {}
+
+    /**
+     * This is the only method that should be used for configuring connection factories for a
+     * {@link org.apache.jmeter.testelement.TestPlan}.
+     * This should always be called from a {@link org.apache.jmeter.threads.SetupThreadGroup} to help prevent
+     * multi-threading issues.
+     *
+     * @param type of connection(s) to set up for this test plan.
+     *
+     * @param context the context to run with. This provides access to initialization parameters.
+     */
+    public static void initConnections(final ConnectionType type, final JavaSamplerContext context) {
+
+        try {
+            final Properties testRuntimeProps = new Properties();
+            testRuntimeProps.load(LdapUtils.getResource("classpath:/org/ldaptive/ldap.properties"));
+            properties = new JMeterRuntimeProperties(testRuntimeProps, context);
+            switch (type) {
+                case ALL:
+                    initAllConnections();
+                    break;
+                case AUTH_DEFAULT_FACTORY:
+                    initAuthDefaultConnectionFactory();
+                    break;
+                case SEARCH_ALL:
+                    initSingleConnectionFactory();
+                    initPooledConnectionFactory();
+                    initSearchDefaultConnectionFactory();
+                    break;
+                case SEARCH_DEFAULT_FACTORY:
+                    initSearchDefaultConnectionFactory();
+                    break;
+                case SEARCH_SINGLE_FACTORY:
+                    initSingleConnectionFactory();
+                    break;
+                case SEARCH_POOLED_FACTORY:
+                    initPooledConnectionFactory();
+                    break;
+            }
+            setupSuccess = true;
+        } catch (LdapException | IOException e) {
+            setupSuccess = false;
+            logger.error("Setup of Connection(s) failed", e);
+        }
+    }
+
+    /**
+     * Reset all static configuration data. This is useful when running test plans via the GUI as we want connections to
+     * be reset between plan executions and this will only happen by reloading the class loader (restarting the GUI).
+     */
+    public static void teardownConfiguration() {
+        setupSuccess = false;
+        searchConnectionConfig = null;
+        authConnectionConfig = null;
+        properties = null;
+        if (singleConnectionFactory != null) {
+            singleConnectionFactory.close();
+            singleConnectionFactory = null;
+        }
+        if (pooledConnectionFactory != null) {
+            pooledConnectionFactory.close();
+            pooledConnectionFactory = null;
+        }
+        if (defaultConnectionFactory != null) {
+            defaultConnectionFactory.close();
+            defaultConnectionFactory = null;
+        }
+        if (authDefaultConnectionFactory != null) {
+            authDefaultConnectionFactory.close();
+            authDefaultConnectionFactory = null;
+        }
+    }
+
+    /**
+     * Initialize all of the connections that are used in the Ldaptive load tests. This can be updated to include
+     * others if load testing expands beyond what is here.
+     *
+     * @throws LdapException when there is an error creating/initializing connections
+     */
+    private static void initAllConnections() throws LdapException {
+        initSearchConnectionConfig();
+        initAuthConnectionConfig();
+        initSingleConnectionFactory();
+        initPooledConnectionFactory();
+        initSearchDefaultConnectionFactory();
+        initAuthDefaultConnectionFactory();
+    }
+
+    /**
+     * Initialize a {@link SingleConnectionFactory} for LDAP searches
+     *
+     * @throws LdapException when there is an error creating/initializing connection
+     */
+    private static void initSingleConnectionFactory() throws LdapException {
+        initSearchConnectionConfig();
+        if (singleConnectionFactory == null) {
+            singleConnectionFactory = newSingleConnectionFactory(searchConnectionConfig);
+        }
+    }
+
+    /**
+     * Initialize a {@link PooledConnectionFactory} for LDAP searches
+     *
+     * @throws LdapException when there is an error creating/initializing connection
+     */
+    private static void initPooledConnectionFactory() throws LdapException {
+        initSearchConnectionConfig();
+        if (pooledConnectionFactory == null) {
+            pooledConnectionFactory = newPooledConnectionFactory(searchConnectionConfig);
+        }
+    }
+
+    /**
+     * Initialize a {@link DefaultConnectionFactory} for LDAP searches
+     *
+     * @throws LdapException when there is an error creating/initializing connection
+     */
+    private static void initSearchDefaultConnectionFactory() throws LdapException {
+        initSearchConnectionConfig();
+        if (defaultConnectionFactory == null) {
+            defaultConnectionFactory = newDefaultConnectionFactory(searchConnectionConfig);
+        }
+    }
+
+    /**
+     * Initialize a {@link DefaultConnectionFactory} for LDAP Authentication
+     *
+     * @throws LdapException when there is an error creating/initializing connection
+     */
+    private static void initAuthDefaultConnectionFactory() throws LdapException {
+        initAuthConnectionConfig();
+        if (authDefaultConnectionFactory == null) {
+            authDefaultConnectionFactory = newDefaultConnectionFactory(authConnectionConfig);
+        }
+    }
+
+    /**
+     * Initialize a {@link ConnectionConfig} for connections performing LDAP Search operations
+     *
+     * @throws LdapException when there is an error creating the config
+     */
+    private static void initSearchConnectionConfig() throws LdapException {
+        if (searchConnectionConfig == null) {
+            searchConnectionConfig = newSearchConnConfig();
+        }
+    }
+
+    /**
+     * Initialize a {@link ConnectionConfig} for connections performing LDAP Authentication operations
+     *
+     * @throws LdapException when there is an error creating the config
+     */
+    private static void initAuthConnectionConfig() throws LdapException {
+        if (authConnectionConfig == null) {
+            authConnectionConfig = newAuthConnConfig();
+        }
+    }
+
+    /**
+     * Get the shared {@link SingleConnectionFactory} for this {@link org.apache.jmeter.testelement.TestPlan}
+     *
+     * @return initialized factory
+     */
+    public static SingleConnectionFactory getSingleConnectionFactory() {
+        return singleConnectionFactory;
+    }
+
+    /**
+     * Get the shared {@link PooledConnectionFactory} for this {@link org.apache.jmeter.testelement.TestPlan}
+     *
+     * @return initialized factory
+     */
+    public static PooledConnectionFactory getPooledConnectionFactory() {
+        return pooledConnectionFactory;
+    }
+
+    /**
+     * Get the shared {@link DefaultConnectionFactory} for this {@link org.apache.jmeter.testelement.TestPlan}
+     *
+     * This should be used for LDAP Search Operations
+     *
+     * @return initialized factory
+     */
+    public static DefaultConnectionFactory getDefaultConnectionFactory() {
+        return defaultConnectionFactory;
+    }
+
+    /**
+     * Get the shared {@link DefaultConnectionFactory} for this {@link org.apache.jmeter.testelement.TestPlan}
+     *
+     * This should be used for LDAP Authentication Operations
+     *
+     * @return initialized factory
+     */
+    public static DefaultConnectionFactory getAuthDefaultConnectionFactory() {
+        return authDefaultConnectionFactory;
+    }
+
+    /**
+     * Flag indicating whether configuration was successful for this {@link org.apache.jmeter.testelement.TestPlan}
+     * This should be checked before tests are executed and before the test
+     * {@link org.apache.jmeter.samplers.SampleResult} is started.
+     *
+     * @return if initial plan config was successful
+     */
+    public static boolean isSetupSuccess() {
+        return setupSuccess;
+    }
+
+    /**
+     * Get shared runtime properties for JMeter tests
+     *
+     * @return initialized properties
+     */
+    public static JMeterRuntimeProperties getProperties() {
+        return properties;
+    }
+
+    /**
+     * Create and initialize a new (shared) {@link DefaultConnectionFactory} for Search or Authentication operations.
+     *
+     * NOTE: use {@link #newSearchConnConfig()} when factory is being used for Search Operations
+     *       OR
+     *       use {@link #newAuthConnConfig()} when factory is being used for Authentication Operations
+     *
+     * @param config for this connectionFactory
+     *
+     * @return initialized factory
+     *
+     * @throws LdapException when a connection cannot be opened/closed as a test of being properly initialized
+     */
+    private static DefaultConnectionFactory newDefaultConnectionFactory(final ConnectionConfig config) throws LdapException {
+        final DefaultConnectionFactory factory = new DefaultConnectionFactory(config);
+        try {
+            factory.getConnection().open();
+            factory.getConnection().close();
+        } catch (LdapException e) {
+            throw new LdapException("DefaultConnectionFactory initialization failed", e);
+        }
+        return factory;
+    }
+
+    /**
+     * Create and initialize a new (shared) {@link SingleConnectionFactory} for Search operations
+     *
+     * @param config for this connectionFactory
+     *
+     * @return initialized factory
+     *
+     * @throws LdapException when factory cannot be initialized.
+     */
+    private static SingleConnectionFactory newSingleConnectionFactory(final ConnectionConfig config) throws LdapException {
+        final SingleConnectionFactory factory = new SingleConnectionFactory(config);
+        try {
+            factory.initialize();
+        } catch (LdapException e) {
+            throw new LdapException("SingleConnectionFactory initialization failed", e);
+        }
+        return factory;
+    }
+
+    /**
+     * Create and initialize a new (shared) {@link PooledConnectionFactory} for Search operations
+     *
+     * @param config for this connectionFactory
+     *
+     * @return initialized factory
+     *
+     * @throws LdapException when factory cannot be initialized.
+     */
+    private static PooledConnectionFactory newPooledConnectionFactory(
+            final ConnectionConfig config) throws LdapException
+    {
+        try {
+            final int minPoolSize = properties.minPoolSize();
+            final int maxPoolSize = properties.maxPoolSize();
+            final PooledConnectionFactory factory = PooledConnectionFactory.builder()
+                    .config(config)
+                    .config(PoolConfig.builder().min(minPoolSize).max(maxPoolSize).build())
+                    .build();
+            factory.initialize();
+            return factory;
+        } catch (Exception e) {
+            throw new LdapException("PooledConnectionFactory initialization failed", e);
+        }
+    }
+
+    /**
+     * {@link org.ldaptive.ConnectionConfig.Builder} with default configuration
+     **
+     * @return builder with the minimum configuration already performed.
+     *
+     * @throws LdapException when configuration cannot be created. This is generally due to Test Properties not being
+     * configured correctly in the {@link org.apache.jmeter.testelement.TestPlan}
+     */
+    private static ConnectionConfig.Builder connectionConfigDefaultBuilder() throws LdapException
+    {
+        try {
+            final String ldapUrl = properties.ldapUrl();
+            final int maxOps = properties.nettyConnectionMaxOps();
+            final boolean useStartTls = properties.useStartTls();
+            final boolean autoReconnect = properties.autoReconnect();
+            setNettyMaxOps(maxOps);
+
+            return ConnectionConfig.builder()
+                    .url(new LdapURL(ldapUrl).getHostnameWithSchemeAndPort())
+                    .useStartTLS(useStartTls)
+                    .sslConfig(SslConfig.builder().trustManagers(new AllowAnyTrustManager()).build())
+                    .autoReconnect(autoReconnect);
+        } catch (Exception ex) {
+            throw new LdapException("Setup failed for ConnectionConfig", ex);
+        }
+    }
+
+    /**
+     * Fully configured {@link ConnectionConfig} that can be used for factories that are doing search operations.
+     *
+     * @return fully configured connection config
+     **/
+    private static ConnectionConfig newSearchConnConfig() throws LdapException {
+        return connectionConfigDefaultBuilder().build();
+    }
+
+    /**
+     * Fully configured {@link ConnectionConfig} that can be used for factories that are doing authentication
+     * operations.
+     *
+     * @return fully configured connection config
+     **/
+    private static ConnectionConfig newAuthConnConfig() throws LdapException {
+        final ConnectionConfig.Builder connectionBuilder = connectionConfigDefaultBuilder();
+        final BindConnectionInitializer bindConnectionInitializer =
+                new BindConnectionInitializer(properties.bindDn(), new Credential(
+                        properties.bindCredential()));
+        connectionBuilder.connectionInitializer(bindConnectionInitializer);
+        return connectionBuilder.build();
+    }
+
+    /**
+     * Set the MAX_CONCURRENT_OPS for the {@link org.ldaptive.Connection} being used for tests
+     *
+     * @param maxOps defined via {@code -JconnMaxOps} program argument. Default is 50
+     */
+    private static void setNettyMaxOps(final int maxOps) throws LdapException {
+        if (maxOps != 50) {
+            logger.info("Setting Netty Max Operations to " + maxOps);
+            final Field field = ReflectionUtils.findField(NettyConnection.class, "MAX_CONCURRENT_OPS");
+            if (field != null) {
+                field.setAccessible(true);
+                Field modifiersField;
+                try {
+                    modifiersField = Field.class.getDeclaredField("modifiers");
+                    modifiersField.setAccessible(true);
+                    modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+                    field.set(null, maxOps);
+                } catch (NoSuchFieldException | IllegalAccessException e) {
+                    throw new LdapException("Exception thrown while setting Netty Max Ops", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Enum for specifying the type of connections that should be initialized for this test plan.
+     */
+    public enum ConnectionType {
+        /** All connection factories should be configured and initialized */
+        ALL,
+        /** Only the DefaultConnectionFactory used for Auth operations should be configured and initialized */
+        AUTH_DEFAULT_FACTORY,
+        /** All connection factories associated with Search operations should be configured and initialized */
+        SEARCH_ALL,
+        /** Only the DefaultConnectionFactory used for Search operations should be configured and initialized */
+        SEARCH_DEFAULT_FACTORY,
+        /** Only the SingleConnectionFactory used for Search operations should be configured and initialized */
+        SEARCH_SINGLE_FACTORY,
+        /** Only the PooledConnectionFactory used for Search operations should be configured and initialized */
+        SEARCH_POOLED_FACTORY
+    }
+}

--- a/integration/src/test/java/org/ldaptive/jmeter/setup_teardown/ThreadGroupProperties.java
+++ b/integration/src/test/java/org/ldaptive/jmeter/setup_teardown/ThreadGroupProperties.java
@@ -1,0 +1,113 @@
+/*
+  See LICENSE for licensing and NOTICE for copyright.
+*/
+package org.ldaptive.jmeter.setup_teardown;
+
+import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
+
+/**
+ * Class that provides access to ThreadGroup details for the purpose of reporting.
+ */
+public final class ThreadGroupProperties {
+
+    /** Number of Threads (Simulated Users) using SingleConnectionFactory for LDAP Searches */
+    private static int searchNumSingleConnectionFactorynUsers;
+
+    /** Number of Threads (Simulated Users) using PooledConnectionFactory for LDAP Searches */
+    private static int searchNumPooledConnectionFactoryUsers;
+
+    /** Number of Threads (Simulated Users) using DefaultConnectionFactory for LDAP Searches */
+    private static int searchNumDefaultConnectionFactoryUsers;
+
+    /** Number of Threads (Simulated Users) using DefaultConnectionFactory for LDAP Bind/Authentication */
+    private static int authNumDefaultConnectionFactoryUsers;
+
+    /** Number of seconds that each group will execute requests */
+    private static int threadRunDuration;
+
+    /**
+     * How many seconds it will take each ThreadGroup to start ALL threads in their group.
+     *
+     * For example, if a thread group has 10 users and ramp-up is 5 seconds, the group will add a new thread every 0.5s
+     */
+    private static int threadRampUp;
+
+    /**
+     * Private constructor. All implementations must use {@link #ThreadGroupProperties(JavaSamplerContext)} (JavaSamplerContext)}
+     */
+    private ThreadGroupProperties() {}
+
+    /**
+     * Instantiate and set ThreadGroup property details for reporting purposes.
+     *
+     * @param context current run context
+     */
+    public ThreadGroupProperties(final JavaSamplerContext context) {
+        searchNumSingleConnectionFactorynUsers = intProp("NUM_SEARCH_SINGLE_USERS", context);
+        searchNumPooledConnectionFactoryUsers = intProp("NUM_SEARCH_POOLED_USERS", context);
+        searchNumDefaultConnectionFactoryUsers = intProp("NUM_SEARCH_DEFAULT_USERS", context);
+        authNumDefaultConnectionFactoryUsers = intProp("NUM_AUTH_DEFAULT_USERS", context);
+        threadRunDuration = intProp("THREAD_TOTAL_RUN_DURATION", context);
+        threadRampUp = intProp("THREAD_USER_RAMP_UP", context);
+    }
+
+    private int intProp(final String propName, final JavaSamplerContext context) {
+        return Integer.parseInt(context.getJMeterVariables().get(propName));
+    }
+
+    /**
+     * @return String representation of details for all ThreadGroups
+     */
+    public String threadGroupPlanDetails() {
+        final StringBuilder stringBuilder = new StringBuilder();
+        final String singleSearch = threadGroupDetails(
+                "Search: SingleConnectionFactory",
+                searchNumSingleConnectionFactorynUsers,
+                threadRunDuration, threadRampUp
+        );
+        final String pooledSearch = threadGroupDetails(
+                "Search: PooledConnectionFactory",
+                searchNumPooledConnectionFactoryUsers,
+                threadRunDuration, threadRampUp
+        );
+        final String defaulSearch = threadGroupDetails(
+                "Search: DefaultConnectionFactory",
+                searchNumDefaultConnectionFactoryUsers,
+                threadRunDuration, threadRampUp
+        );
+        final String defultAuth = threadGroupDetails(
+                "Authentication: DefaultConnectionFactory",
+                authNumDefaultConnectionFactoryUsers,
+                threadRunDuration, threadRampUp
+        );
+        stringBuilder.append("Thread Group Details").append(System.lineSeparator())
+                .append(singleSearch)
+                .append(pooledSearch)
+                .append(defaulSearch)
+                .append(defultAuth);
+        return stringBuilder.toString();
+    }
+
+    /**
+     * @param name of ThreadGroup
+     * @param numThreads that will be started for this group
+     * @param threadRunDuration number of seconds that this group will execute requests
+     * @param threadRampUp number of seconds it will take to start all threads in this group
+     * @return String representation of a single ThreadGroup details
+     */
+    private static String threadGroupDetails(
+            final String name,
+            final int numThreads,
+            final int threadRunDuration,
+            final int threadRampUp)
+    {
+        return "\t" + name +
+                System.lineSeparator() +
+                "\t\t" + "Num Threads: " + numThreads +
+                System.lineSeparator() +
+                "\t\t" + "Thread Ramp-up: " + threadRampUp + " seconds" +
+                System.lineSeparator() +
+                "\t\t" + "Group Run Duration: " + threadRunDuration + " seconds" +
+                System.lineSeparator();
+    }
+}

--- a/integration/src/test/jmeter/LdaptiveLoadTestingPlan.jmx
+++ b/integration/src/test/jmeter/LdaptiveLoadTestingPlan.jmx
@@ -1,0 +1,1033 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.1.1 r1855137">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="LdaptiveLoadTestingAllPlan" enabled="true">
+      <stringProp name="TestPlan.comments">Tests Search operations with Single, Pooled, and Default factories. Tests Auth operations with Default factory.</stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">true</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+    </TestPlan>
+    <hashTree>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="AUTH_FILTER" elementType="Argument">
+            <stringProp name="Argument.name">AUTH_FILTER</stringProp>
+            <stringProp name="Argument.value">${__P(authFilter, (uid={user}))}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="AUTH_REQUEST_ID" elementType="Argument">
+            <stringProp name="Argument.name">AUTH_REQUEST_ID</stringProp>
+            <stringProp name="Argument.value">${__P(authRequestId, 1)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="BASE_DN" elementType="Argument">
+            <stringProp name="Argument.name">BASE_DN</stringProp>
+            <stringProp name="Argument.value">${__P(baseDn, ou=test\,dc=vt\,dc=edu)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="BIND_CREDENTIAL" elementType="Argument">
+            <stringProp name="Argument.name">BIND_CREDENTIAL</stringProp>
+            <stringProp name="Argument.value">${__P(bindCredential, undefined)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="BIND_DN" elementType="Argument">
+            <stringProp name="Argument.name">BIND_DN</stringProp>
+            <stringProp name="Argument.value">${__P(bindDn, uid=1\,ou=test\,dc=vt\,dc=edu)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="CONNECTION_AUTO_RECONNECT" elementType="Argument">
+            <stringProp name="Argument.name">CONNECTION_AUTO_RECONNECT</stringProp>
+            <stringProp name="Argument.value">${__P(autoReconnect, false)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="CONNECTION_MAX_OPS" elementType="Argument">
+            <stringProp name="Argument.name">CONNECTION_MAX_OPS</stringProp>
+            <stringProp name="Argument.value">${__P(connMaxOps, 50)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="CONNECTION_USE_START_TLS" elementType="Argument">
+            <stringProp name="Argument.name">CONNECTION_USE_START_TLS</stringProp>
+            <stringProp name="Argument.value">${__P(useStartTls, true)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="LDAP_URL" elementType="Argument">
+            <stringProp name="Argument.name">LDAP_URL</stringProp>
+            <stringProp name="Argument.value">${__P(ldapUrl, ldap://ldap-test)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="MAX_POOL_SIZE" elementType="Argument">
+            <stringProp name="Argument.name">MAX_POOL_SIZE</stringProp>
+            <stringProp name="Argument.value">${__P(maxPoolSize, 10)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="MIN_POOL_SIZE" elementType="Argument">
+            <stringProp name="Argument.name">MIN_POOL_SIZE</stringProp>
+            <stringProp name="Argument.value">${__P(minPoolSize, 10)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="SEARCH_FILTER" elementType="Argument">
+            <stringProp name="Argument.name">SEARCH_FILTER</stringProp>
+            <stringProp name="Argument.value">${__P(searchFilter, (uid={1}))}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="THREAD_GROUP_NUM_USERS" elementType="Argument">
+            <stringProp name="Argument.name">THREAD_GROUP_NUM_USERS</stringProp>
+            <stringProp name="Argument.value">${__P(numUsers, 10)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="THREAD_TOTAL_RUN_DURATION" elementType="Argument">
+            <stringProp name="Argument.name">THREAD_TOTAL_RUN_DURATION</stringProp>
+            <stringProp name="Argument.value">${__P(runDuration, 15)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="THREAD_USER_RAMP_UP" elementType="Argument">
+            <stringProp name="Argument.name">THREAD_USER_RAMP_UP</stringProp>
+            <stringProp name="Argument.value">${__P(userRampUp, 10)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="User Group Specific Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="NUM_SEARCH_SINGLE_USERS" elementType="Argument">
+            <stringProp name="Argument.name">NUM_SEARCH_SINGLE_USERS</stringProp>
+            <stringProp name="Argument.value">${__P(numSearchSingleUsers, ${THREAD_GROUP_NUM_USERS})}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="NUM_SEARCH_POOLED_USERS" elementType="Argument">
+            <stringProp name="Argument.name">NUM_SEARCH_POOLED_USERS</stringProp>
+            <stringProp name="Argument.value">${__P(numSearchPooledUsers, ${THREAD_GROUP_NUM_USERS})}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="NUM_SEARCH_DEFAULT_USERS" elementType="Argument">
+            <stringProp name="Argument.name">NUM_SEARCH_DEFAULT_USERS</stringProp>
+            <stringProp name="Argument.value">${__P(numSearchDefaultUsers, ${THREAD_GROUP_NUM_USERS})}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="NUM_AUTH_DEFAULT_USERS" elementType="Argument">
+            <stringProp name="Argument.name">NUM_AUTH_DEFAULT_USERS</stringProp>
+            <stringProp name="Argument.value">${__P(numAuthDefaultUsers, ${THREAD_GROUP_NUM_USERS})}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </Arguments>
+      <hashTree/>
+      <SetupThreadGroup guiclass="SetupThreadGroupGui" testclass="SetupThreadGroup" testname="setUp Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </SetupThreadGroup>
+      <hashTree>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="SetupSampler" enabled="true">
+          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="classname">org.ldaptive.jmeter.setup_teardown.SetupSampler</stringProp>
+        </JavaSampler>
+        <hashTree/>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Search - Users: SingleConnectionFactory" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">stoptest</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <intProp name="LoopController.loops">-1</intProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">${NUM_SEARCH_SINGLE_USERS}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${THREAD_USER_RAMP_UP}</stringProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.duration">${THREAD_TOTAL_RUN_DURATION}</stringProp>
+        <stringProp name="ThreadGroup.delay">5</stringProp>
+        <boolProp name="ThreadGroup.delayedStart">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Search - SingleConnectionFactory" enabled="true">
+          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="classname">org.ldaptive.jmeter.sampler.SingleConnectionSearchSampler</stringProp>
+        </JavaSampler>
+        <hashTree>
+          <UniformRandomTimer guiclass="UniformRandomTimerGui" testclass="UniformRandomTimer" testname="Uniform Random Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">0</stringProp>
+            <stringProp name="RandomTimer.range">100.0</stringProp>
+          </UniformRandomTimer>
+          <hashTree/>
+        </hashTree>
+        <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+          <boolProp name="useGroupName">true</boolProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <kg.apc.jmeter.vizualizers.CorrectedResultCollector guiclass="kg.apc.jmeter.vizualizers.ThroughputVsThreadsGui" testclass="kg.apc.jmeter.vizualizers.CorrectedResultCollector" testname="jp@gc - Transaction Throughput vs Threads" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+          <longProp name="interval_grouping">500</longProp>
+          <boolProp name="graph_aggregated">false</boolProp>
+          <stringProp name="include_sample_labels"></stringProp>
+          <stringProp name="exclude_sample_labels"></stringProp>
+          <stringProp name="start_offset"></stringProp>
+          <stringProp name="end_offset"></stringProp>
+          <boolProp name="include_checkbox_state">false</boolProp>
+          <boolProp name="exclude_checkbox_state">false</boolProp>
+        </kg.apc.jmeter.vizualizers.CorrectedResultCollector>
+        <hashTree/>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Search - Users: PooledConnectionFactory" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">stoptest</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <intProp name="LoopController.loops">-1</intProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">${NUM_SEARCH_POOLED_USERS}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${THREAD_USER_RAMP_UP}</stringProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.duration">${THREAD_TOTAL_RUN_DURATION}</stringProp>
+        <stringProp name="ThreadGroup.delay">3</stringProp>
+        <boolProp name="ThreadGroup.delayedStart">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Search - PooledConnectionFactory" enabled="true">
+          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="classname">org.ldaptive.jmeter.sampler.PooledConnectionSearchSampler</stringProp>
+        </JavaSampler>
+        <hashTree>
+          <UniformRandomTimer guiclass="UniformRandomTimerGui" testclass="UniformRandomTimer" testname="Uniform Random Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">0</stringProp>
+            <stringProp name="RandomTimer.range">100.0</stringProp>
+          </UniformRandomTimer>
+          <hashTree/>
+        </hashTree>
+        <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+          <boolProp name="useGroupName">true</boolProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <kg.apc.jmeter.vizualizers.CorrectedResultCollector guiclass="kg.apc.jmeter.vizualizers.ThroughputVsThreadsGui" testclass="kg.apc.jmeter.vizualizers.CorrectedResultCollector" testname="jp@gc - Transaction Throughput vs Threads" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+          <longProp name="interval_grouping">500</longProp>
+          <boolProp name="graph_aggregated">false</boolProp>
+          <stringProp name="include_sample_labels"></stringProp>
+          <stringProp name="exclude_sample_labels"></stringProp>
+          <stringProp name="start_offset"></stringProp>
+          <stringProp name="end_offset"></stringProp>
+          <boolProp name="include_checkbox_state">false</boolProp>
+          <boolProp name="exclude_checkbox_state">false</boolProp>
+        </kg.apc.jmeter.vizualizers.CorrectedResultCollector>
+        <hashTree/>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Search - Users: DefaultConnectionFactory" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">stoptest</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <intProp name="LoopController.loops">-1</intProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">${NUM_SEARCH_DEFAULT_USERS}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${THREAD_USER_RAMP_UP}</stringProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.duration">${THREAD_TOTAL_RUN_DURATION}</stringProp>
+        <stringProp name="ThreadGroup.delay">3</stringProp>
+        <boolProp name="ThreadGroup.delayedStart">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Search - DefaultConnectionFactory" enabled="true">
+          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="classname">org.ldaptive.jmeter.sampler.DefaultConnectionSearchSampler</stringProp>
+        </JavaSampler>
+        <hashTree>
+          <UniformRandomTimer guiclass="UniformRandomTimerGui" testclass="UniformRandomTimer" testname="Uniform Random Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">0</stringProp>
+            <stringProp name="RandomTimer.range">100.0</stringProp>
+          </UniformRandomTimer>
+          <hashTree/>
+        </hashTree>
+        <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+          <boolProp name="useGroupName">true</boolProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <kg.apc.jmeter.vizualizers.CorrectedResultCollector guiclass="kg.apc.jmeter.vizualizers.ThroughputVsThreadsGui" testclass="kg.apc.jmeter.vizualizers.CorrectedResultCollector" testname="jp@gc - Transaction Throughput vs Threads" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+          <longProp name="interval_grouping">500</longProp>
+          <boolProp name="graph_aggregated">false</boolProp>
+          <stringProp name="include_sample_labels"></stringProp>
+          <stringProp name="exclude_sample_labels"></stringProp>
+          <stringProp name="start_offset"></stringProp>
+          <stringProp name="end_offset"></stringProp>
+          <boolProp name="include_checkbox_state">false</boolProp>
+          <boolProp name="exclude_checkbox_state">false</boolProp>
+        </kg.apc.jmeter.vizualizers.CorrectedResultCollector>
+        <hashTree/>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Auth - Users: DefaultConnectionFactory" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">stoptest</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <intProp name="LoopController.loops">-1</intProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">${NUM_AUTH_DEFAULT_USERS}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${THREAD_USER_RAMP_UP}</stringProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.duration">${THREAD_TOTAL_RUN_DURATION}</stringProp>
+        <stringProp name="ThreadGroup.delay">3</stringProp>
+        <boolProp name="ThreadGroup.delayedStart">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Auth - DefaultConnectionFactory" enabled="true">
+          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="classname">org.ldaptive.jmeter.sampler.DefaultConnectionAuthSampler</stringProp>
+        </JavaSampler>
+        <hashTree>
+          <UniformRandomTimer guiclass="UniformRandomTimerGui" testclass="UniformRandomTimer" testname="Uniform Random Timer" enabled="true">
+            <stringProp name="ConstantTimer.delay">0</stringProp>
+            <stringProp name="RandomTimer.range">100.0</stringProp>
+          </UniformRandomTimer>
+          <hashTree/>
+        </hashTree>
+        <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <kg.apc.jmeter.vizualizers.CorrectedResultCollector guiclass="kg.apc.jmeter.vizualizers.ThroughputVsThreadsGui" testclass="kg.apc.jmeter.vizualizers.CorrectedResultCollector" testname="jp@gc - Transaction Throughput vs Threads" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+          <longProp name="interval_grouping">500</longProp>
+          <boolProp name="graph_aggregated">false</boolProp>
+          <stringProp name="include_sample_labels"></stringProp>
+          <stringProp name="exclude_sample_labels"></stringProp>
+          <stringProp name="start_offset"></stringProp>
+          <stringProp name="end_offset"></stringProp>
+          <boolProp name="include_checkbox_state">false</boolProp>
+          <boolProp name="exclude_checkbox_state">false</boolProp>
+        </kg.apc.jmeter.vizualizers.CorrectedResultCollector>
+        <hashTree/>
+      </hashTree>
+      <PostThreadGroup guiclass="PostThreadGroupGui" testclass="PostThreadGroup" testname="tearDown Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </PostThreadGroup>
+      <hashTree>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="TeardownSampler" enabled="true">
+          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="classname">org.ldaptive.jmeter.setup_teardown.TeardownSampler</stringProp>
+        </JavaSampler>
+        <hashTree/>
+      </hashTree>
+      <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>false</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+        <boolProp name="saveHeaders">false</boolProp>
+      </ResultCollector>
+      <hashTree/>
+      <kg.apc.jmeter.vizualizers.CorrectedResultCollector guiclass="kg.apc.jmeter.vizualizers.ThroughputVsThreadsGui" testclass="kg.apc.jmeter.vizualizers.CorrectedResultCollector" testname="jp@gc - Transaction Throughput vs Threads" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+        <longProp name="interval_grouping">500</longProp>
+        <boolProp name="graph_aggregated">false</boolProp>
+        <stringProp name="include_sample_labels"></stringProp>
+        <stringProp name="exclude_sample_labels"></stringProp>
+        <stringProp name="start_offset"></stringProp>
+        <stringProp name="end_offset"></stringProp>
+        <boolProp name="include_checkbox_state">false</boolProp>
+        <boolProp name="exclude_checkbox_state">false</boolProp>
+      </kg.apc.jmeter.vizualizers.CorrectedResultCollector>
+      <hashTree/>
+      <kg.apc.jmeter.vizualizers.CompositeResultCollector guiclass="kg.apc.jmeter.vizualizers.CompositeGraphGui" testclass="kg.apc.jmeter.vizualizers.CompositeResultCollector" testname="jp@gc - Composite Graph" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <sentBytes>true</sentBytes>
+            <url>true</url>
+            <threadCounts>true</threadCounts>
+            <idleTime>true</idleTime>
+            <connectTime>true</connectTime>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+        <longProp name="interval_grouping">500</longProp>
+        <boolProp name="graph_aggregated">false</boolProp>
+        <stringProp name="include_sample_labels"></stringProp>
+        <stringProp name="exclude_sample_labels"></stringProp>
+        <stringProp name="start_offset"></stringProp>
+        <stringProp name="end_offset"></stringProp>
+        <boolProp name="include_checkbox_state">false</boolProp>
+        <boolProp name="exclude_checkbox_state">false</boolProp>
+        <collectionProp name="COMPOSITE_CFG">
+          <collectionProp name=""/>
+          <collectionProp name=""/>
+        </collectionProp>
+      </kg.apc.jmeter.vizualizers.CompositeResultCollector>
+      <hashTree/>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/integration/src/test/jmeter/README.md
+++ b/integration/src/test/jmeter/README.md
@@ -1,0 +1,93 @@
+## JMeter Throughput Testing
+
+Throughput testing will occur during the `verify` phase of the project build lifecycle.
+See `Alternative Standalone Execution` for running tests manually.
+
+Testing will include basic `search` and `auth` operations executing against the test ldap server that is started as 
+part of integration testing.
+
+#### JMeter Requirements
+
+  - All `.jmx` test plan files must be in `src/test/jmeter` or one of its subdirectories
+  - Tests are executed in the Maven `verify` phase
+  - Java classes that are used in the test plan must be packaged and copied to `/target/jmeter/lib/ext` (previous 
+    requirement supports this)
+
+#### Default Test Parameters
+
+  - authFilter : (uid={user})
+  - authRequestId : 1
+  - baseDn : ou=test,dc=vt,dc=edu
+  - bindDn : uid=1,ou=test,dc=vt,dc=edu
+  - ldapUrl : ldap://ldap-test
+  - searchFilter : (uid={1})
+  - numUsers : 10
+    - This is the global (can be overridden for individual thread groups) number of threads (simulated users) that 
+      JMeter will create for each test in each test plan.
+      A single .jmx file should be 1 test plan.
+    - numSearchSingleUsers : Number of threads for Search Operations using a SingleConnectionFactory. Defaults to 
+      `${numUsers}`
+    - numSearchPooledUsers : Number of threads for Search Operations using a PooledConnectionFactory. Defaults to 
+      `${numUsers}`
+    - numSearchDefaultUsers : Number of threads for Search Operations using a DefaultConnectionFactory. Defaults to 
+      `${numUsers}`
+    - numAuthDefaultUsers : Number of threads for Search Operations using a DefaultConnectionFactory. Defaults to 
+      `${numUsers}`
+  - userRampUp : 10 (should be <= `runDuration`)
+    - This is the number of seconds it will take JMeter to start ALL threads for a test. For example, if a test uses
+      20 threads and the ramp-up time is 20 seconds, JMeter will start 1 thread every 1 second. A test that uses 20
+      threads with a ramp-up of 10 seconds will start a thread every half second. A good starting point is to have
+      `userRampUp == numUsers` and adjust up/down as needed.
+  - runDuration : 15 (seconds)
+    - How long the entire test will execute. This should be at least a few seconds longer than the `userRampUp` so the
+      last thread has time to contribute to the load testing.
+  - connMaxOps : 50
+    - org.ldaptive.provider.netty.NettyConnection#MAX_CONCURRENT_OPS
+    - The library default is 50
+  - useStartTls : true
+    - `org.ldaptive.ConnectionConfig#useStartTLS`
+  - autoReconnect : false
+    - `org.ldaptive.ConnectionConfig#autoReconnect`
+  - minPoolSize : 10
+    - The initial number of connections in a PooledConnectionFactory
+  - maxPoolSize : 10
+    - The maximum number of connections in a PooledConnectionFactory
+    
+#### Overriding Default Test Parameters
+
+All of the parameters above can be overridden in the `jmeter-maven-plugin` via the `<propertiesUser>` section under
+`<configuration>`.
+Example:
+  ```xml
+  <configuration>
+    <propertiesUser>
+      <ldapUrl>ldap://some-other-url</ldapUrl>
+      <numUsers>250</numUsers>
+    </propertiesUser>
+  </configuration>
+  ```
+ 
+#### View Results
+
+Once the integration tests finish the results can be viewed in the JMeter Dashboard by opening 
+`integration/target/jmeter/results/index.html`.
+Additional graphs can be viewed by starting the JMeter GUI, opening the current TestPlan and importing the results 
+(csv) file in `integration/target/jmeter/results/*.csv`
+
+#### Alternative Standalone Execution
+
+Test plans can be executed outside of ldaptive integration testing by following the steps below.
+  - Download and unpack JMeter locally
+  - Start a local LDAP server or have the necessary server info of a remote LDAP instance
+  - Execute the tests via:
+    - GUI: Good for a visual of the tests and their execution, but shouldn't be used if max load testing is desired.
+      - Start the JMeter GUI by executing the `jmeter` script in the `bin` folder of the JMeter installation and 
+        provide the desired test plan via the `-t` flag. 
+        Ex: `jmeter-install/bin/jmeter -t /dir/to/plan/LdaptiveLoadTestingPlan.jmx`
+      - Provide test parameters via the `User Defined Variables` in the test plan.
+      - Hit the play button
+    - JMeter CLI: This is recommended way for executing load tests!
+      - `jmeter-install/bin/jmeter -n -t /dir/to/plan/LdaptiveLoadTestingPlan.jmx -l /dir/to/logfile/filename.csv 
+         -JparamName=someVal`
+        - Custom properties are provided as flags prefixed with `-J`. Ex: `-JldapUrl=ldap://ldapHost` 
+


### PR DESCRIPTION
Added load testing for:
Search operations using SingleConnectionFactory,
PooledConnectionFactory, and DefaultConnectionFactory.

Authentication operations using DefaultConnectionFactory.

All tests use JMeter to execute the tests with user-defined number
other threads, execution time, etc... See README in src/test/jmeter for
additional info.

Tests generate minimal reports in the terminal output and more complex
reports in /target/jmeter/reports