### PR TITLE
Refactor LdapException to support result codes.

### DIFF
--- a/core/src/main/java/org/ldaptive/ConnectException.java
+++ b/core/src/main/java/org/ldaptive/ConnectException.java
@@ -16,33 +16,36 @@ public class ConnectException extends LdapException
   /**
    * Creates a new connect exception.
    *
+   * @param  code result code describing this exception
    * @param  msg  describing this exception
    */
-  public ConnectException(final String msg)
+  public ConnectException(final ResultCode code, final String msg)
   {
-    super(msg);
+    super(code, msg);
   }
 
 
   /**
    * Creates a new connect exception.
    *
+   * @param  code result code describing this exception
    * @param  e  underlying exception
    */
-  public ConnectException(final Throwable e)
+  public ConnectException(final ResultCode code, final Throwable e)
   {
-    super(e);
+    super(code, e);
   }
 
 
   /**
    * Creates a new connect exception.
    *
+   * @param  code result code describing this exception
    * @param  msg  describing this exception
    * @param  e  underlying exception
    */
-  public ConnectException(final String msg, final Throwable e)
+  public ConnectException(final ResultCode code, final String msg, final Throwable e)
   {
-    super(msg, e);
+    super(code, msg, e);
   }
 }

--- a/core/src/main/java/org/ldaptive/LdapException.java
+++ b/core/src/main/java/org/ldaptive/LdapException.java
@@ -12,6 +12,9 @@ public class LdapException extends Exception
   /** serialVersionUID. */
   private static final long serialVersionUID = 6812614366508784841L;
 
+  /** Optional result code associated with this exception. */
+  private final ResultCode resultCode;
+
 
   /**
    * Creates a new ldap exception based on the supplied result.
@@ -20,7 +23,7 @@ public class LdapException extends Exception
    */
   public LdapException(final Result result)
   {
-    this(formatResult(result));
+    this(result.getResultCode(), formatResult(result));
   }
 
 
@@ -31,7 +34,20 @@ public class LdapException extends Exception
    */
   public LdapException(final String msg)
   {
+    this(null, msg);
+  }
+
+
+  /**
+   * Creates a new ldap exception.
+   *
+   * @param  code result code describing this exception
+   * @param  msg  describing this exception
+   */
+  public LdapException(final ResultCode code, final String msg)
+  {
     super(msg);
+    resultCode = code;
   }
 
 
@@ -42,7 +58,20 @@ public class LdapException extends Exception
    */
   public LdapException(final Throwable e)
   {
+    this((ResultCode) null, e);
+  }
+
+
+  /**
+   * Creates a new ldap exception.
+   *
+   * @param  code result code describing this exception
+   * @param  e  underlying exception
+   */
+  public LdapException(final ResultCode code, final Throwable e)
+  {
     super(e);
+    resultCode = code;
   }
 
 
@@ -54,7 +83,32 @@ public class LdapException extends Exception
    */
   public LdapException(final String msg, final Throwable e)
   {
+    this(null, msg, e);
+  }
+
+
+  /**
+   * Creates a new ldap exception.
+   *
+   * @param  code result code describing this exception
+   * @param  msg  describing this exception
+   * @param  e  underlying exception
+   */
+  public LdapException(final ResultCode code, final String msg, final Throwable e)
+  {
     super(msg, e);
+    resultCode = code;
+  }
+
+
+  /**
+   * Returns the result code.
+   *
+   * @return  result code or null
+   */
+  public ResultCode getResultCode()
+  {
+    return resultCode;
   }
 
 

--- a/core/src/main/java/org/ldaptive/auth/AggregateAuthenticationHandler.java
+++ b/core/src/main/java/org/ldaptive/auth/AggregateAuthenticationHandler.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.ldaptive.LdapException;
+import org.ldaptive.ResultCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +84,9 @@ public class AggregateAuthenticationHandler implements AuthenticationHandler
     final String[] labeledDn = criteria.getDn().split(":", 2);
     final AuthenticationHandler ah = authenticationHandlers.get(labeledDn[0]);
     if (ah == null) {
-      throw new LdapException("Could not find authentication handler for label: " + labeledDn[0]);
+      throw new LdapException(
+        ResultCode.PARAM_ERROR,
+        "Could not find authentication handler for label: " + labeledDn[0]);
     }
     return ah.authenticate(new AuthenticationCriteria(labeledDn[1], criteria.getAuthenticationRequest()));
   }

--- a/core/src/main/java/org/ldaptive/auth/AggregateAuthenticationResponseHandler.java
+++ b/core/src/main/java/org/ldaptive/auth/AggregateAuthenticationResponseHandler.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.ldaptive.LdapException;
+import org.ldaptive.ResultCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +84,7 @@ public class AggregateAuthenticationResponseHandler implements AuthenticationRes
     final String[] labeledDn = response.getResolvedDn().split(":", 2);
     final AuthenticationResponseHandler[] handlers = responseHandlers.get(labeledDn[0]);
     if (handlers == null) {
-      throw new LdapException("Could not find response handlers for label: " + labeledDn[0]);
+      throw new LdapException(ResultCode.PARAM_ERROR, "Could not find response handlers for label: " + labeledDn[0]);
     }
     if (handlers.length > 0) {
       for (AuthenticationResponseHandler ah : handlers) {

--- a/core/src/main/java/org/ldaptive/auth/AggregateEntryResolver.java
+++ b/core/src/main/java/org/ldaptive/auth/AggregateEntryResolver.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
+import org.ldaptive.ResultCode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,7 +85,7 @@ public class AggregateEntryResolver implements EntryResolver
     final String[] labeledDn = criteria.getDn().split(":", 2);
     final EntryResolver er = entryResolvers.get(labeledDn[0]);
     if (er == null) {
-      throw new LdapException("Could not find entry resolver for label: " + labeledDn[0]);
+      throw new LdapException(ResultCode.PARAM_ERROR, "Could not find entry resolver for label: " + labeledDn[0]);
     }
     return er.resolve(new AuthenticationCriteria(labeledDn[1], criteria.getAuthenticationRequest()), response);
   }

--- a/core/src/main/java/org/ldaptive/auth/CompareAuthenticationHandler.java
+++ b/core/src/main/java/org/ldaptive/auth/CompareAuthenticationHandler.java
@@ -11,6 +11,7 @@ import org.ldaptive.ConnectionFactory;
 import org.ldaptive.Credential;
 import org.ldaptive.LdapException;
 import org.ldaptive.LdapUtils;
+import org.ldaptive.ResultCode;
 
 /**
  * Provides implementation common to compare authentication handlers.
@@ -133,7 +134,7 @@ public class CompareAuthenticationHandler extends AbstractAuthenticationHandler
       md.update(credential.getBytes());
       return md.digest();
     } catch (NoSuchAlgorithmException e) {
-      throw new LdapException(e);
+      throw new LdapException(ResultCode.AUTH_UNKNOWN, e);
     }
   }
 

--- a/core/src/main/java/org/ldaptive/ext/MergeOperation.java
+++ b/core/src/main/java/org/ldaptive/ext/MergeOperation.java
@@ -102,6 +102,7 @@ public class MergeOperation
       if (searchResult.getResultCode() != ResultCode.SUCCESS &&
           searchResult.getResultCode() != ResultCode.NO_SUCH_OBJECT) {
         throw new LdapException(
+          searchResult.getResultCode(),
           String.format(
             "Error searching for entry: %s, response did not return success or no_such_object: %s",
             sourceEntry,

--- a/core/src/main/java/org/ldaptive/filter/AbstractFilterFunction.java
+++ b/core/src/main/java/org/ldaptive/filter/AbstractFilterFunction.java
@@ -1,6 +1,8 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.ldaptive.filter;
 
+import org.ldaptive.ResultCode;
+
 /**
  * Base implementation to parse an LDAP search filter string.
  *
@@ -18,11 +20,15 @@ public abstract class AbstractFilterFunction implements FilterFunction
     // Check for balanced parentheses
     if (filter.startsWith("(")) {
       if (!filter.endsWith(")")) {
-        throw new FilterParseException("Unbalanced parentheses. Opening paren without closing paren.");
+        throw new FilterParseException(
+          ResultCode.FILTER_ERROR,
+          "Unbalanced parentheses. Opening paren without closing paren.");
       }
       balancedFilter = filter;
     } else if (filter.endsWith(")")) {
-      throw new FilterParseException("Unbalanced parentheses. Closing paren without opening paren.");
+      throw new FilterParseException(
+        ResultCode.FILTER_ERROR,
+        "Unbalanced parentheses. Closing paren without opening paren.");
     } else {
       // Allow entire filter strings without enclosing parentheses
       balancedFilter = "(".concat(filter).concat(")");
@@ -46,7 +52,9 @@ public abstract class AbstractFilterFunction implements FilterFunction
   {
     final int end = filter.length() - 1;
     if (filter.charAt(0) != '(' || filter.charAt(end) != ')') {
-      throw new FilterParseException("Filter must be surround by parentheses: '" + filter + "'");
+      throw new FilterParseException(
+        ResultCode.FILTER_ERROR,
+        "Filter must be surround by parentheses: '" + filter + "'");
     }
     int pos = 1;
     final Filter searchFilter;
@@ -68,7 +76,7 @@ public abstract class AbstractFilterFunction implements FilterFunction
       // attempt to match a non-set filter type
       searchFilter = parseFilterComp(filter);
       if (searchFilter == null) {
-        throw new FilterParseException("Could not determine filter type for '" + filter + "'");
+        throw new FilterParseException(ResultCode.FILTER_ERROR, "Could not determine filter type for '" + filter + "'");
       }
       break;
     }
@@ -94,13 +102,15 @@ public abstract class AbstractFilterFunction implements FilterFunction
     int pos = start;
     int closeIndex = findMatchingParenPosition(filter, pos);
     if (filter.charAt(pos) != '(' || closeIndex == -1 || closeIndex == end) {
-      throw new FilterParseException("Invalid filter syntax, missing parenthesis after " + set.getType());
+      throw new FilterParseException(
+        ResultCode.FILTER_ERROR,
+        "Invalid filter syntax, missing parenthesis after " + set.getType());
     }
     while (pos < end) {
       try {
         set.add(readNextComponent(filter.substring(pos, closeIndex + 1)));
       } catch (Exception e) {
-        throw new FilterParseException(e);
+        throw new FilterParseException(ResultCode.FILTER_ERROR, e);
       }
       pos = closeIndex + 1;
       if (pos < end) {
@@ -126,10 +136,10 @@ public abstract class AbstractFilterFunction implements FilterFunction
     throws FilterParseException
   {
     if (filter == null || filter.length() == 0) {
-      throw new FilterParseException("Filter cannot be null or empty");
+      throw new FilterParseException(ResultCode.FILTER_ERROR, "Filter cannot be null or empty");
     }
     if (filter.charAt(start) != '(') {
-      throw new FilterParseException("Filter must begin with '('");
+      throw new FilterParseException(ResultCode.FILTER_ERROR, "Filter must begin with '('");
     }
     int pos = start + 1;
     int parenCount = 1;

--- a/core/src/main/java/org/ldaptive/filter/FilterParseException.java
+++ b/core/src/main/java/org/ldaptive/filter/FilterParseException.java
@@ -2,6 +2,7 @@
 package org.ldaptive.filter;
 
 import org.ldaptive.LdapException;
+import org.ldaptive.ResultCode;
 
 /**
  * Exception that indicates an invalid filter string.
@@ -18,33 +19,36 @@ public class FilterParseException extends LdapException
   /**
    * Creates a new filter parse exception.
    *
+   * @param  code result code describing this exception
    * @param  msg  describing this exception
    */
-  public FilterParseException(final String msg)
+  public FilterParseException(final ResultCode code, final String msg)
   {
-    super(msg);
+    super(code, msg);
   }
 
 
   /**
    * Creates a new filter parse exception.
    *
+   * @param  code result code describing this exception
    * @param  e  underlying exception
    */
-  public FilterParseException(final Throwable e)
+  public FilterParseException(final ResultCode code, final Throwable e)
   {
-    super(e);
+    super(code, e);
   }
 
 
   /**
    * Creates a new filter parse exception.
    *
+   * @param  code result code describing this exception
    * @param  msg  describing this exception
    * @param  e  underlying exception
    */
-  public FilterParseException(final String msg, final Throwable e)
+  public FilterParseException(final ResultCode code, final String msg, final Throwable e)
   {
-    super(msg, e);
+    super(code, msg, e);
   }
 }

--- a/core/src/main/java/org/ldaptive/filter/FilterUtils.java
+++ b/core/src/main/java/org/ldaptive/filter/FilterUtils.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.ldaptive.LdapUtils;
+import org.ldaptive.ResultCode;
 
 /**
  * Provides utility methods for this package.
@@ -111,13 +112,15 @@ public final class FilterUtils
     for (int i = 0; i < value.length(); i++) {
       final char c = value.charAt(i);
       if (c == '\0' || c == '(' || c == ')') {
-        throw new FilterParseException("Assertion value contains unescaped characters");
+        throw new FilterParseException(ResultCode.FILTER_ERROR, "Assertion value contains unescaped characters");
       } else if (c == '\\') {
         final char[] hexValue = new char[]{value.charAt(++i), value.charAt(++i)};
         try {
           bytes.write(LdapUtils.hexDecode(hexValue));
         } catch (IOException e) {
-          throw new FilterParseException("Could not hex decode " + Arrays.toString(hexValue) + " in " + value);
+          throw new FilterParseException(
+            ResultCode.FILTER_ERROR,
+            "Could not hex decode " + Arrays.toString(hexValue) + " in " + value);
         }
       } else {
         bytes.write(c);

--- a/core/src/main/java/org/ldaptive/filter/RegexFilterFunction.java
+++ b/core/src/main/java/org/ldaptive/filter/RegexFilterFunction.java
@@ -3,6 +3,7 @@ package org.ldaptive.filter;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.ldaptive.ResultCode;
 
 /**
  * Parses an LDAP search filter string using regular expressions.
@@ -159,7 +160,7 @@ public class RegexFilterFunction extends AbstractFilterFunction
             endsWith != null ? FilterUtils.parseAssertionValue(endsWith) : null,
             contains != null ? FilterUtils.parseAssertionValue(contains) : null);
         } catch (IllegalArgumentException e) {
-          throw new FilterParseException(e);
+          throw new FilterParseException(ResultCode.FILTER_ERROR, e);
         }
       }
     }
@@ -189,7 +190,7 @@ public class RegexFilterFunction extends AbstractFilterFunction
       try {
         return new ExtensibleFilter(rule, attr, FilterUtils.parseAssertionValue(value), dn);
       } catch (IllegalArgumentException e) {
-        throw new FilterParseException(e);
+        throw new FilterParseException(ResultCode.FILTER_ERROR, e);
       }
       // CheckStyle:MagicNumber ON
     }
@@ -276,7 +277,7 @@ public class RegexFilterFunction extends AbstractFilterFunction
     for (String s : values) {
       final Matcher m = ESCAPE_CHARS_PATTERN.matcher(s);
       if  (m.find()) {
-        throw new FilterParseException("Invalid filter syntax, contains unescaped characters");
+        throw new FilterParseException(ResultCode.FILTER_ERROR, "Invalid filter syntax, contains unescaped characters");
       }
     }
   }

--- a/core/src/main/java/org/ldaptive/transport/TransportConnection.java
+++ b/core/src/main/java/org/ldaptive/transport/TransportConnection.java
@@ -11,6 +11,7 @@ import org.ldaptive.ConnectionStrategy;
 import org.ldaptive.InitialRetryMetadata;
 import org.ldaptive.LdapException;
 import org.ldaptive.LdapURL;
+import org.ldaptive.ResultCode;
 import org.ldaptive.RetryMetadata;
 import org.ldaptive.UnbindRequest;
 import org.slf4j.Logger;
@@ -70,7 +71,7 @@ public abstract class TransportConnection implements Connection
     if (openLock.tryLock()) {
       try {
         if (isOpen()) {
-          throw new ConnectException("Connection is already open");
+          throw new ConnectException(ResultCode.CONNECT_ERROR, "Connection is already open");
         }
         final RetryMetadata metadata = new InitialRetryMetadata(lastSuccessfulOpen);
         LdapException lastThrown;
@@ -96,7 +97,7 @@ public abstract class TransportConnection implements Connection
       }
     } else {
       LOGGER.warn("Open lock {} could not be acquired by {}", openLock, Thread.currentThread());
-      throw new LdapException("Open in progress");
+      throw new LdapException(ResultCode.CONNECT_ERROR, "Open in progress");
     }
   }
 
@@ -125,7 +126,7 @@ public abstract class TransportConnection implements Connection
     if (openLock.tryLock()) {
       try {
         if (isOpen()) {
-          throw new ConnectException("Connection is already open");
+          throw new ConnectException(ResultCode.CONNECT_ERROR, "Connection is already open");
         }
         LdapException lastThrown = null;
         while (connectionConfig.getAutoReconnectCondition().test(metadata)) {
@@ -150,7 +151,7 @@ public abstract class TransportConnection implements Connection
       }
     } else {
       LOGGER.warn("Open lock {} could not be acquired by {}", openLock, Thread.currentThread());
-      throw new LdapException("Open in progress");
+      throw new LdapException(ResultCode.CONNECT_ERROR, "Open in progress");
     }
   }
 

--- a/core/src/main/java/org/ldaptive/transport/netty/HandleMap.java
+++ b/core/src/main/java/org/ldaptive/transport/netty/HandleMap.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.ldaptive.LdapException;
+import org.ldaptive.ResultCode;
 import org.ldaptive.extended.UnsolicitedNotification;
 import org.ldaptive.transport.DefaultOperationHandle;
 import org.slf4j.Logger;
@@ -97,7 +98,7 @@ final class HandleMap
     throws LdapException
   {
     if (!open) {
-      throw new LdapException("Connection is closed, could not store handle " + handle);
+      throw new LdapException(ResultCode.CONNECT_ERROR, "Connection is closed, could not store handle " + handle);
     }
     return pending.putIfAbsent(id, handle);
   }
@@ -161,11 +162,11 @@ final class HandleMap
 
   /**
    * Notifies all operation handles in the queue that an exception has occurred. See {@link
-   * DefaultOperationHandle#exception(Throwable)}. This method removes all handles from the queue.
+   * DefaultOperationHandle#exception(LdapException)}. This method removes all handles from the queue.
    *
    * @param  e  exception to provides to handles
    */
-  public void notifyOperationHandles(final Throwable e)
+  public void notifyOperationHandles(final LdapException e)
   {
     if (notificationLock.compareAndSet(false, true)) {
       try {

--- a/core/src/test/java/org/ldaptive/transport/mock/MockConnection.java
+++ b/core/src/test/java/org/ldaptive/transport/mock/MockConnection.java
@@ -20,6 +20,7 @@ import org.ldaptive.ModifyDnResponse;
 import org.ldaptive.ModifyRequest;
 import org.ldaptive.ModifyResponse;
 import org.ldaptive.OperationHandle;
+import org.ldaptive.ResultCode;
 import org.ldaptive.SearchOperationHandle;
 import org.ldaptive.SearchRequest;
 import org.ldaptive.UnbindRequest;
@@ -87,7 +88,7 @@ public final class MockConnection extends TransportConnection
     throws LdapException
   {
     if (!openPredicate.test(url)) {
-      throw new ConnectException("Cannot connect to " + url.getHostnameWithSchemeAndPort());
+      throw new ConnectException(ResultCode.CONNECT_ERROR, "Cannot connect to " + url.getHostnameWithSchemeAndPort());
     }
     ldapURL = url;
     open = true;


### PR DESCRIPTION
This patch changes the LdapException class to require a result code.
While that code may be legitimately null in some cases, this allows the impl to thoughtfully consider the use of client side result codes.