### PR TITLE
DERPath performance improvements.

### DIFF
--- a/core/src/main/java/org/ldaptive/asn1/DERParser.java
+++ b/core/src/main/java/org/ldaptive/asn1/DERParser.java
@@ -31,18 +31,6 @@ public class DERParser
 
 
   /**
-   * See {@link #registerHandler(DERPath, ParseHandler)}.
-   *
-   * @param  path  to register
-   * @param  handler  to associate with the path
-   */
-  public void registerHandler(final String path, final ParseHandler handler)
-  {
-    registerHandler(new DERPath(path), handler);
-  }
-
-
-  /**
    * Registers the supplied handler to fire when the supplied path is encountered.
    *
    * @param  path  to register

--- a/core/src/main/java/org/ldaptive/asn1/DERPath.java
+++ b/core/src/main/java/org/ldaptive/asn1/DERPath.java
@@ -72,7 +72,7 @@ public class DERPath
     for (UniversalDERTag tag : UniversalDERTag.values()) {
       validNames.append('|').append(tag.name());
     }
-    NODE_PATTERN = Pattern.compile(String.format("(%s)(\\[(\\d+)\\])?", validNames.toString()));
+    NODE_PATTERN = Pattern.compile(String.format("(%s)(?:\\[(\\d+)\\])?", validNames.toString()));
   }
 
   /** Describes the path as a FIFO set of nodes. */
@@ -208,7 +208,12 @@ public class DERPath
   @Override
   public int hashCode()
   {
-    return LdapUtils.computeHashCode(HASH_CODE_SEED, nodeStack);
+    int hc = HASH_CODE_SEED;
+    int index = 1;
+    for (Node n : nodeStack) {
+      hc += n.hashCode() * index++;
+    }
+    return hc;
   }
 
 
@@ -241,7 +246,7 @@ public class DERPath
     }
 
     final String name = matcher.group(1);
-    final String index = matcher.group(3);
+    final String index = matcher.group(2);
     if (index != null) {
       return new Node(name, Integer.parseInt(index));
     }
@@ -335,7 +340,9 @@ public class DERPath
     @Override
     public int hashCode()
     {
-      return LdapUtils.computeHashCode(HASH_CODE_SEED, name, childIndex);
+      int result = HASH_CODE_SEED + (name == null ? 0 : name.hashCode());
+      result = HASH_CODE_SEED * result + childIndex;
+      return result;
     }
 
 

--- a/core/src/main/java/org/ldaptive/asn1/DERPath.java
+++ b/core/src/main/java/org/ldaptive/asn1/DERPath.java
@@ -209,9 +209,8 @@ public class DERPath
   public int hashCode()
   {
     int hc = HASH_CODE_SEED;
-    int index = 1;
     for (Node n : nodeStack) {
-      hc += n.hashCode() * index++;
+      hc = HASH_CODE_SEED * hc + n.hashCode();
     }
     return hc;
   }

--- a/core/src/test/java/org/ldaptive/asn1/DERPathTest.java
+++ b/core/src/test/java/org/ldaptive/asn1/DERPathTest.java
@@ -53,6 +53,20 @@ public class DERPathTest
 
   /** @throws  Exception  On test failure. */
   @Test(groups = "asn1")
+  public void testHashCode()
+    throws Exception
+  {
+    Assert.assertEquals(new DERPath("SEQ").hashCode(), new DERPath("SEQ").hashCode());
+    Assert.assertNotEquals(new DERPath("ENUM").hashCode(), new DERPath("INT").hashCode());
+    Assert.assertEquals(
+      new DERPath("APP(0)").pushNode("CTX(0)").hashCode(), new DERPath("APP(0)").pushNode("CTX(0)").hashCode());
+    Assert.assertNotEquals(
+      new DERPath("APP(0)").pushNode("CTX(0)").hashCode(), new DERPath("CTX(0)").pushNode("APP(0)").hashCode());
+  }
+
+
+  /** @throws  Exception  On test failure. */
+  @Test(groups = "asn1")
   public void testEquals()
     throws Exception
   {

--- a/core/src/test/java/org/ldaptive/asn1/DERPathTest.java
+++ b/core/src/test/java/org/ldaptive/asn1/DERPathTest.java
@@ -33,6 +33,26 @@ public class DERPathTest
 
   /** @throws  Exception  On test failure. */
   @Test(groups = "asn1")
+  public void testToNode()
+    throws Exception
+  {
+    Assert.assertEquals(DERPath.toNode("SEQ").getName(), "SEQ");
+    Assert.assertEquals(DERPath.toNode("SEQ").getChildIndex(), -1);
+    Assert.assertEquals(DERPath.toNode("APP(4)").getName(), "APP(4)");
+    Assert.assertEquals(DERPath.toNode("APP(4)").getChildIndex(), -1);
+    Assert.assertEquals(DERPath.toNode("ENUM[0]").getName(), "ENUM");
+    Assert.assertEquals(DERPath.toNode("ENUM[0]").getChildIndex(), 0);
+    Assert.assertEquals(DERPath.toNode("OCTSTR[1]").getName(), "OCTSTR");
+    Assert.assertEquals(DERPath.toNode("OCTSTR[1]").getChildIndex(), 1);
+    Assert.assertEquals(DERPath.toNode("INT[3]").getName(), "INT");
+    Assert.assertEquals(DERPath.toNode("INT[3]").getChildIndex(), 3);
+    Assert.assertEquals(DERPath.toNode("CTX(0)").getName(), "CTX(0)");
+    Assert.assertEquals(DERPath.toNode("CTX(0)").getChildIndex(), -1);
+  }
+
+
+  /** @throws  Exception  On test failure. */
+  @Test(groups = "asn1")
   public void testEquals()
     throws Exception
   {


### PR DESCRIPTION
Remove the ability to register a DERPath by string to emphasize the use of static DERPath objects.
Change regex to use non-capturing group.
Under load the hashCode implementation in DERPath was shown to be a hotspot due to all the collection operations.
Simplify the hashCode implementation to improve performance.