### PR TITLE
Add maven module to aid in library profiling.

### DIFF
--- a/mvn_cmd
+++ b/mvn_cmd
@@ -15,7 +15,7 @@ function run_mvn() {
 
 case "$1" in
   clean)
-    run_mvn integration,benchmark,distribution clean
+    run_mvn integration,benchmark,profile,distribution clean
     ;;
   javadoc)
     run_mvn javadoc:javadoc
@@ -38,10 +38,10 @@ case "$1" in
     run_mvn distribution versions:set "-DnewVersion=${VERSION} -DgenerateBackupPoms=false"
     ;;
   versions-display-dependency)
-    run_mvn integration,benchmark,distribution versions:display-dependency-updates
+    run_mvn integration,benchmark,profile,distribution versions:display-dependency-updates
     ;;
   versions-display-plugin)
-    run_mvn integration,benchmark,distribution versions:display-plugin-updates
+    run_mvn integration,benchmark,profile,distribution versions:display-plugin-updates
     ;;
   deploy)
     LOCAL_REPO=${2}

--- a/pom.xml
+++ b/pom.xml
@@ -496,6 +496,12 @@
       </modules>
     </profile>
     <profile>
+      <id>profile</id>
+      <modules>
+        <module>profile</module>
+      </modules>
+    </profile>
+    <profile>
       <id>distribution</id>
       <modules>
         <module>distribution</module>

--- a/profile/docker-compose.yml
+++ b/profile/docker-compose.yml
@@ -1,0 +1,53 @@
+version: "3.7"
+
+services:
+  ldaptive:
+    image: maven:3.6-jdk-11
+    ports:
+      - 9003:9003
+      - 10001:10001
+    volumes:
+      - $HOME/.m2:/root/.m2
+      - $PWD:/apps/ldaptive
+    environment:
+      - HOST=ldap-test
+      - PORT=389
+      - BASE_DN=ou=test,dc=vt,dc=edu
+      - BIND_DN=uid=1,ou=test,dc=vt,dc=edu
+      - BIND_CREDENTIAL=VKSxXwlU7YssGl1foLMH2mGMWkifbODb1djfJ4t2
+      - PROFILE_CLASS
+      - THREAD_COUNT
+      - THREAD_SLEEP
+      - ITERATIONS
+      - USE_YOURKIT
+    networks:
+      ldap_net:
+        ipv4_address: 172.28.1.10
+    command: >
+      bash -c "cd /apps/ldaptive && profile/run"
+
+  ldap-test:
+    image: dhawes/ldap-test-openldap:latest
+    ports:
+      - "389:389"
+      - "10389:10389"
+      - "636:636"
+      - "10636:10636"
+      - "88:88"
+    networks:
+      ldap_net:
+        ipv4_address: 172.28.1.11
+    logging:
+      #driver: "json-file"
+      driver: "none"
+      options:
+        max-size: "100M"
+        max-file: "5"
+
+networks:
+  ldap_net:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.0.0/16
+

--- a/profile/pom.xml
+++ b/profile/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>ldaptive-profile</artifactId>
+  <packaging>jar</packaging>
+  <name>LDAPTIVE PROFILING</name>
+  <description>Ldaptive profile</description>
+  <parent>
+    <groupId>org.ldaptive</groupId>
+    <artifactId>ldaptive-parent</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.ldaptive</groupId>
+      <artifactId>ldaptive</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/profile/run
+++ b/profile/run
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [ -z "${PROFILE_CLASS}" ]; then
+  PROFILE_CLASS="org.ldaptive.SingleSearchOperationProfile"
+fi
+
+if [ -z "${THREAD_COUNT}" ]; then
+  THREAD_COUNT=50
+fi
+
+if [ -z "${THREAD_SLEEP}" ]; then
+  THREAD_SLEEP=10
+fi
+
+if [ -z "${ITERATIONS}" ]; then
+  ITERATIONS=-1
+fi
+
+if [ -z "${USE_YOURKIT}" ]; then
+  # jconsole options
+  export MAVEN_OPTS="-Djava.rmi.server.hostname=0.0.0.0 -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=10001 -Dcom.sun.management.jmxremote.rmi.port=9003 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:NativeMemoryTracking=summary"
+else
+  # yourkit options
+  export MAVEN_OPTS="-agentpath:profile/yourkit_2019.8/bin/linux-x86-64/libyjpagent.so=port=10001,listen=all"
+fi
+
+echo ""
+echo "####################################"
+echo "# Attach profiler to localhost:10001"
+echo "####################################"
+echo ""
+
+mvn -Dmaven.javadoc.skip=true -B -V -e \
+  -DldapBaseDn="${BASE_DN}" \
+  -DldapBindDn="${BIND_DN}" \
+  -DldapBindCredential="${BIND_CREDENTIAL}" \
+  -pl profile -Pprofile clean compile exec:java -Dexec.mainClass=${PROFILE_CLASS} -Dexec.args="${PROFILE_CLASS} ${HOST} ${PORT} ${THREAD_COUNT} ${THREAD_SLEEP} ${ITERATIONS}"

--- a/profile/run-compose
+++ b/profile/run-compose
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+## SCRIPT VARIABLES
+# PROFILE_CLASS: java class to profile
+# THREAD_COUNT: number of threads to execute operations
+# THREAD_SLEEP: time in milliseconds to wait between submitting operations, ignored if ITERATIONS is used
+# ITERATIONS: number of operations to invoke, no value means execute indefinitely
+# USE_YOURKIT: whether to set MAVEN_OPTS for the yourkit profiler, default is for jconsole
+
+docker-compose -f profile/docker-compose.yml down && \
+  docker network prune -f && \
+  docker-compose -f profile/docker-compose.yml pull && \
+  docker-compose -f profile/docker-compose.yml up --build --abort-on-container-exit

--- a/profile/src/main/java/org/ldaptive/AbstractProfile.java
+++ b/profile/src/main/java/org/ldaptive/AbstractProfile.java
@@ -1,0 +1,231 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import org.ldaptive.handler.ResultPredicate;
+
+/**
+ * Base class for profiling.
+ *
+ * @author  Middleware Services
+ */
+public abstract class AbstractProfile
+{
+
+  /** Number to start with for UID creation. */
+  protected static final int UID_START = 1001;
+
+  /** Number of operations performed. */
+  private static final AtomicInteger COUNT = new AtomicInteger();
+
+
+  /**
+   * Main method for executing a profile.
+   *
+   * @param  args  command line arguments
+   *
+   * @throws  Exception  on an unexpected error
+   */
+  // CheckStyle:MagicNumber OFF
+  public static void main(final String[] args)
+    throws Exception
+  {
+    final String clazz = args[0];
+    final String host = args[1];
+    final int port = Integer.parseInt(args[2]);
+    final int threadCount = Integer.parseInt(args[3]);
+    final int threadSleep = Integer.parseInt(args[4]);
+    final int iterations = Integer.parseInt(args[5]);
+
+    final AbstractProfile test = createInstance(Class.forName(clazz));
+    test.setBaseDn(System.getProperty("ldapBaseDn"));
+    test.setBindDn(System.getProperty("ldapBindDn"));
+    test.setBindCredential(System.getProperty("ldapBindCredential"));
+    test.initialize(host, port);
+    test.createEntries(100);
+
+    System.out.println();
+    System.out.println("##############################");
+    System.out.println("# Start profile for " + test);
+    System.out.println("#   threadCount: " + threadCount);
+    System.out.println("#   threadSleep: " + threadSleep);
+    System.out.println("#   iterations: " + iterations);
+    System.out.println("##############################");
+    System.out.println();
+    final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    if (iterations == -1) {
+      final ScheduledExecutorService counter = Executors.newSingleThreadScheduledExecutor();
+      counter.scheduleAtFixedRate(
+        () -> System.out.println("  " + LocalDateTime.now() + ": received " + COUNT + " results "),
+        10,
+        10,
+        TimeUnit.SECONDS);
+      final Random r = new Random();
+      while (true) {
+        final int uid = r.nextInt(100) + UID_START;
+        executor.submit(() -> test.doOperation(
+          o -> {
+            if (o == null) {
+              System.out.println("RECEIVED NULL RESULT");
+            } else {
+              COUNT.getAndIncrement();
+            }
+          },
+          uid));
+        if (threadSleep > 0) {
+          Thread.sleep(threadSleep);
+        }
+      }
+    } else {
+      final List<Callable<Void>> callables = new ArrayList<>(iterations);
+      final CountDownLatch latch = new CountDownLatch(iterations);
+      final Random r = new Random();
+      for (int i = 0; i < iterations; i++) {
+        final int uid = r.nextInt(100) + 1001;
+        callables.add(() -> {
+          test.doOperation(
+            o -> {
+              if (o == null) {
+                System.out.println("RECEIVED NULL RESULT");
+              } else {
+                COUNT.getAndIncrement();
+              }
+              latch.countDown();
+            },
+            uid);
+          return null;
+        });
+      }
+      long t = System.currentTimeMillis();
+      executor.invokeAll(callables);
+      latch.await();
+      t = System.currentTimeMillis() - t;
+      System.out.println("##############################");
+      System.out.println("# End profile for " + test + " in " + t + "ms : " + COUNT + " results");
+      System.out.println("##############################");
+    }
+
+    test.shutdown();
+    executor.shutdown();
+    executor.awaitTermination(10, TimeUnit.SECONDS);
+  }
+  // CheckStyle:MagicNumber ON
+
+
+  /**
+   * Creates a concrete instance of the profile class.
+   *
+   * @param  clazz  profile class that will run
+   *
+   * @return  new instance of a profile class
+   */
+  private static AbstractProfile createInstance(final Class<?> clazz)
+  {
+    try {
+      return (AbstractProfile) clazz.getConstructor().newInstance();
+    } catch (Exception e) {
+      throw new IllegalStateException("Could not create class", e);
+    }
+  }
+
+
+  /**
+   * Prepare this profile for use.
+   *
+   * @param  host  to connect to
+   * @param  port  to connect to
+   */
+  protected abstract void initialize(String host, int port);
+
+
+  /**
+   * Creates entries needed for searching.
+   *
+   * @param  count  number of entries to create
+   */
+  protected abstract void createEntries(int count);
+
+
+  /**
+   * Sets a base DN.
+   *
+   * @param  dn  base DN
+   */
+  protected abstract void setBaseDn(String dn);
+
+
+  /**
+   * Sets a bind DN.
+   *
+   * @param  dn  bind DN
+   */
+  protected abstract void setBindDn(String dn);
+
+
+  /**
+   * Sets a bind DN password.
+   *
+   * @param  pass  bind DN password
+   */
+  protected abstract void setBindCredential(String pass);
+
+
+  /**
+   * Perform an LDAP operation.
+   *
+   * @param  consumer  to collect results
+   * @param  uid  to perform operation on
+   */
+  protected abstract void doOperation(Consumer<Object> consumer, int uid);
+
+
+  /**
+   * Clean up any resources associated with this profile.
+   */
+  protected abstract void shutdown();
+
+
+  /**
+   * Create LDAP entries.
+   *
+   * @param  cf  connection factory to create entries with
+   * @param  start  uid to start creation at
+   * @param  count  number of entries to create
+   */
+  protected static void createEntries(final ConnectionFactory cf, final int start, final int count)
+  {
+    final AddOperation create = AddOperation.builder()
+      .factory(cf)
+      .throwIf(ResultPredicate.NOT_SUCCESS)
+      .build();
+    for (int i = start; i < start + count; i++) {
+      try {
+        create.execute(
+          AddRequest.builder()
+            .dn(String.format("uid=%s,ou=test,dc=vt,dc=edu", i))
+            .attributes(
+              LdapAttribute.builder().name("uid").values(Integer.toString(i)).build(),
+              LdapAttribute.builder().name("cn").values("Test User").build(),
+              LdapAttribute.builder().name("givenName").values("Test").build(),
+              LdapAttribute.builder().name("sn").values("User").build(),
+              LdapAttribute.builder()
+                .name("objectClass").values("organizationalPerson", "person", "top", "inetOrgPerson").build(),
+              LdapAttribute.builder().name("userPassword").values(String.format("password%s", i)).build())
+            .build());
+      } catch (LdapException e) {
+        throw new IllegalStateException("Could not create entry", e);
+      }
+    }
+  }
+}

--- a/profile/src/main/java/org/ldaptive/AbstractSearchOperationProfile.java
+++ b/profile/src/main/java/org/ldaptive/AbstractSearchOperationProfile.java
@@ -1,0 +1,89 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive;
+
+import java.util.function.Consumer;
+import org.ldaptive.handler.ResultPredicate;
+
+/**
+ * Base class for profiling connection factories.
+ *
+ * @author  Middleware Services
+ */
+public abstract class AbstractSearchOperationProfile extends AbstractProfile
+{
+
+  /** Connection factory. */
+  protected ConnectionFactory connectionFactory;
+
+  /** Base DN. */
+  protected String baseDn;
+
+  /** Bind DN. */
+  protected String bindDn;
+
+  /** Bind credential. */
+  protected String bindCredential;
+
+
+  @Override
+  protected void shutdown()
+  {
+    connectionFactory.close();
+  }
+
+
+  @Override
+  protected void setBaseDn(final String dn)
+  {
+    baseDn = dn;
+  }
+
+
+  @Override
+  protected void setBindDn(final String dn)
+  {
+    bindDn = dn;
+  }
+
+
+  @Override
+  protected void setBindCredential(final String pass)
+  {
+    bindCredential = pass;
+  }
+
+
+  @Override
+  protected void doOperation(final Consumer<Object> consumer, final int uid)
+  {
+    final SearchOperation search = new SearchOperation(connectionFactory);
+    search.setThrowCondition(ResultPredicate.NOT_SUCCESS);
+    search.setEntryHandlers(e -> {
+      consumer.accept(e);
+      return e;
+    });
+    try {
+      search.send(SearchRequest.builder()
+        .dn(baseDn)
+        .filter("(uid=" + uid + ")")
+        .returnAttributes(ReturnAttributes.ALL_USER.value())
+        .build());
+    } catch (LdapException e) {
+      System.out.println("CAUGHT EXCEPTION:: " + e.getMessage());
+    }
+  }
+
+
+  @Override
+  protected void createEntries(final int count)
+  {
+    createEntries(connectionFactory, UID_START, count);
+  }
+
+
+  @Override
+  public String toString()
+  {
+    return connectionFactory != null ? connectionFactory.toString() : "[null connection factory]";
+  }
+}

--- a/profile/src/main/java/org/ldaptive/DefaultSearchOperationProfile.java
+++ b/profile/src/main/java/org/ldaptive/DefaultSearchOperationProfile.java
@@ -1,0 +1,27 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive;
+
+/**
+ * Class for profiling {@link DefaultConnectionFactory}.
+ *
+ * @author  Middleware Services
+ */
+public final class DefaultSearchOperationProfile extends AbstractSearchOperationProfile
+{
+
+
+  @Override
+  protected void initialize(final String host, final int port)
+  {
+    connectionFactory = DefaultConnectionFactory.builder()
+      .config(ConnectionConfig.builder()
+        .url(new LdapURL(host, port).getUrl())
+        .connectionInitializers(
+          BindConnectionInitializer.builder()
+            .dn(bindDn)
+            .credential(bindCredential)
+            .build())
+        .build())
+      .build();
+  }
+}

--- a/profile/src/main/java/org/ldaptive/PooledSearchOperationProfile.java
+++ b/profile/src/main/java/org/ldaptive/PooledSearchOperationProfile.java
@@ -1,0 +1,33 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive;
+
+/**
+ * Class for profiling {@link PooledConnectionFactory}.
+ *
+ * @author  Middleware Services
+ */
+public final class PooledSearchOperationProfile extends AbstractSearchOperationProfile
+{
+
+  /** Default pool size. */
+  private static final int POOL_SIZE = 10;
+
+
+  @Override
+  protected void initialize(final String host, final int port)
+  {
+    connectionFactory = PooledConnectionFactory.builder()
+      .config(ConnectionConfig.builder()
+        .url(new LdapURL(host, port).getUrl())
+        .connectionInitializers(
+          BindConnectionInitializer.builder()
+            .dn(bindDn)
+            .credential(bindCredential)
+            .build())
+        .build())
+      .min(POOL_SIZE)
+      .max(POOL_SIZE)
+      .build();
+    ((PooledConnectionFactory) connectionFactory).initialize();
+  }
+}

--- a/profile/src/main/java/org/ldaptive/SingleSearchOperationProfile.java
+++ b/profile/src/main/java/org/ldaptive/SingleSearchOperationProfile.java
@@ -1,0 +1,32 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive;
+
+/**
+ * Class for profiling {@link SingleConnectionFactory}.
+ *
+ * @author  Middleware Services
+ */
+public final class SingleSearchOperationProfile extends AbstractSearchOperationProfile
+{
+
+
+  @Override
+  protected void initialize(final String host, final int port)
+  {
+    connectionFactory = SingleConnectionFactory.builder()
+      .config(ConnectionConfig.builder()
+        .url(new LdapURL(host, port).getUrl())
+        .connectionInitializers(
+          BindConnectionInitializer.builder()
+            .dn(bindDn)
+            .credential(bindCredential)
+            .build())
+        .build())
+      .build();
+    try {
+      ((SingleConnectionFactory) connectionFactory).initialize();
+    } catch (LdapException e) {
+      throw new IllegalStateException("Could not initialize connection factory", e);
+    }
+  }
+}

--- a/profile/src/main/java/org/ldaptive/auth/AuthenticatorProfile.java
+++ b/profile/src/main/java/org/ldaptive/auth/AuthenticatorProfile.java
@@ -1,0 +1,148 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.auth;
+
+import java.util.function.Consumer;
+import org.ldaptive.AbstractProfile;
+import org.ldaptive.BindConnectionInitializer;
+import org.ldaptive.ConnectionConfig;
+import org.ldaptive.ConnectionFactory;
+import org.ldaptive.Credential;
+import org.ldaptive.LdapException;
+import org.ldaptive.LdapURL;
+import org.ldaptive.PooledConnectionFactory;
+import org.ldaptive.ReturnAttributes;
+
+/**
+ * Class for profiling {@link Authenticator}.
+ *
+ * @author  Middleware Services
+ */
+public class AuthenticatorProfile extends AbstractProfile
+{
+
+  /** Default pool size. */
+  private static final int POOL_SIZE = 10;
+
+  /** Authenticator. */
+  protected Authenticator authenticator;
+
+  /** DN resolver connection factory. */
+  protected ConnectionFactory resolverConnectionFactory;
+
+  /** Bind connection factory. */
+  protected ConnectionFactory bindConnectionFactory;
+
+  /** Base DN. */
+  protected String baseDn;
+
+  /** Bind DN. */
+  protected String bindDn;
+
+  /** Bind credential. */
+  protected String bindCredential;
+
+
+  @Override
+  protected void initialize(final String host, final int port)
+  {
+    resolverConnectionFactory = newConnectionFactory(host, port, POOL_SIZE);
+    bindConnectionFactory = newConnectionFactory(host, port, POOL_SIZE);
+    authenticator = Authenticator.builder()
+      .dnResolver(SearchDnResolver.builder()
+        .dn(baseDn)
+        .filter("(uid={user})")
+        .subtreeSearch(true)
+        .factory(resolverConnectionFactory)
+        .build())
+      .authenticationHandler(new SimpleBindAuthenticationHandler(bindConnectionFactory))
+      .returnAttributes(ReturnAttributes.ALL_USER.value())
+      .build();
+  }
+
+
+  /**
+   * Creates a new pooled connection factory.
+   *
+   * @param  host  to connect to
+   * @param  port  to connect to
+   * @param  size  of the pool
+   *
+   * @return  pooled connection factory
+   */
+  private PooledConnectionFactory newConnectionFactory(final String host, final int port, final int size)
+  {
+    final PooledConnectionFactory connectionFactory = PooledConnectionFactory.builder()
+      .config(ConnectionConfig.builder()
+        .url(new LdapURL(host, port).getUrl())
+        .connectionInitializers(
+          BindConnectionInitializer.builder()
+            .dn(bindDn)
+            .credential(bindCredential)
+            .build())
+        .build())
+      .min(size)
+      .max(size)
+      .build();
+    connectionFactory.initialize();
+    return connectionFactory;
+  }
+
+
+  @Override
+  protected void shutdown()
+  {
+    resolverConnectionFactory.close();
+    bindConnectionFactory.close();
+  }
+
+
+  @Override
+  protected void setBaseDn(final String dn)
+  {
+    baseDn = dn;
+  }
+
+
+  @Override
+  protected void setBindDn(final String dn)
+  {
+    bindDn = dn;
+  }
+
+
+  @Override
+  protected void setBindCredential(final String pass)
+  {
+    bindCredential = pass;
+  }
+
+
+  @Override
+  protected void doOperation(final Consumer<Object> consumer, final int uid)
+  {
+    try {
+      final AuthenticationResponse result = authenticator.authenticate(
+        new AuthenticationRequest(String.valueOf(uid), new Credential("password" + uid)));
+      if (!result.isSuccess()) {
+        System.out.println("AUTHENTICATION FAILURE: " + result);
+      }
+      consumer.accept(result);
+    } catch (LdapException e) {
+      System.out.println("CAUGHT EXCEPTION:: " + e.getMessage());
+    }
+  }
+
+
+  @Override
+  protected void createEntries(final int count)
+  {
+    createEntries(bindConnectionFactory, UID_START, count);
+  }
+
+
+  @Override
+  public String toString()
+  {
+    return authenticator != null ? authenticator.toString() : "[null authenticator]";
+  }
+}

--- a/profile/src/main/resources/log4j.xml
+++ b/profile/src/main/resources/log4j.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/"
+                     debug="false">
+
+  <appender name="CONSOLE"
+            class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.out"/>
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%X{host} %d %-5p [%c] %m%n"/>
+    </layout>
+  </appender>
+
+  <category name="org.ldaptive"
+            additivity="false">
+    <priority value="DEBUG"/>
+    <appender-ref ref="CONSOLE"/>
+  </category>
+
+  <category name="org.ldaptive.ad"
+            additivity="false">
+    <priority value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </category>
+
+  <category name="org.ldaptive.async"
+            additivity="false">
+    <priority value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </category>
+
+  <category name="org.ldaptive.auth"
+            additivity="false">
+    <priority value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </category>
+
+  <category name="org.ldaptive.beans"
+            additivity="false">
+    <priority value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </category>
+
+  <category name="org.ldaptive.jaas"
+            additivity="false">
+    <priority value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </category>
+
+  <category name="org.ldaptive.pool"
+            additivity="false">
+    <priority value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </category>
+
+  <category name="org.ldaptive.props"
+            additivity="false">
+    <priority value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </category>
+
+  <category name="org.ldaptive.ssl"
+            additivity="false">
+    <priority value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </category>
+
+  <category name="org.ldaptive.transport"
+            additivity="false">
+    <priority value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </category>
+
+  <category name="org.ldaptive.io"
+            additivity="false">
+    <priority value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </category>
+
+  <category name="io.netty.channel"
+            additivity="false">
+    <priority value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </category>
+
+  <root>
+    <priority value="INFO"/>
+    <appender-ref ref="CONSOLE"/>
+  </root>
+
+</log4j:configuration>

--- a/profile/yourkit_2019.8/license-redist.txt
+++ b/profile/yourkit_2019.8/license-redist.txt
@@ -1,0 +1,36 @@
+The following files can be redistributed under the license below:
+
+yjpagent.dll
+libyjpagent.so
+libyjpagent.dylib
+yjp-controller-api-redist.jar
+
+-------------------------------------------------------------------
+
+Copyright (c) 2003-2020, YourKit
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the name of YourKit nor the
+  names of its contributors may be used to endorse or promote products
+  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY YOURKIT "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL YOURKIT BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Configures a docker container that executes an ldaptive class with various configuration parameters.
Exposes the necessary ports so that attaching a profiler is easy.
Supports jconsole and yourkit.

Execute: `mvn install` then `profile/run-compose` to test