### PR TITLE
Remove reference to missing trust manager

### DIFF
--- a/docs/guide/connections.md
+++ b/docs/guide/connections.md
@@ -69,7 +69,6 @@ If you have a implementation of javax.net.ssl.TrustManager it can be added direc
 
 - AggregateTrustManager - combines multiple trust managers allowing the use of all trust managers or any trust manager to pass validation
 - DefaultTrustManager - the default JVM trust managers
-- HostnameVerifyingTrustManager - custom trust manager based on certificate hostname
 - AllowAnyTrustManager - trusts any client or server
 
 Note that if you provide both trust managers and a credential config to the SslConfig, all trust managers will be required.


### PR DESCRIPTION
Closes #183 

By the way, you shouldn't need to host javadocs in gh-pages branch. It makes the repository size explode after a while. This might be a sufficient option:
https://javadoc.io/doc/org.ldaptive/ldaptive/latest/index.html