### PR TITLE
Refactor validator to provide async methods

### DIFF
--- a/core/src/main/java/org/ldaptive/AbstractConnectionValidator.java
+++ b/core/src/main/java/org/ldaptive/AbstractConnectionValidator.java
@@ -2,6 +2,12 @@
 package org.ldaptive;
 
 import java.time.Duration;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base class for connection validator implementations.
@@ -16,6 +22,9 @@ public abstract class AbstractConnectionValidator implements ConnectionValidator
 
   /** Default per connection validate timeout, value is 5 seconds. */
   public static final Duration DEFAULT_VALIDATE_TIMEOUT = Duration.ofSeconds(5);
+
+  /** Logger for this class. */
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
 
   /** Validation period. */
   private Duration validatePeriod;
@@ -52,6 +61,38 @@ public abstract class AbstractConnectionValidator implements ConnectionValidator
       throw new IllegalArgumentException("Timeout cannot be null or negative");
     }
     validateTimeout = timeout;
+  }
+
+
+  @Override
+  public Boolean apply(final Connection conn)
+  {
+    if (conn == null) {
+      return false;
+    }
+    return applyAsync(conn).get();
+  }
+
+
+  @Override
+  public Supplier<Boolean> applyAsync(final Connection conn)
+  {
+    final BlockingQueue<Boolean> queue = new ArrayBlockingQueue<>(1);
+    applyAsync(conn, queue::add);
+    return () -> {
+      Boolean validateResult = null;
+      try {
+        if (Duration.ZERO.equals(getValidateTimeout())) {
+          // this configuration depends on the connection config response timeout for it's wait behavior
+          validateResult = queue.take();
+        } else {
+          validateResult = queue.poll(getValidateTimeout().toMillis(), TimeUnit.MILLISECONDS);
+        }
+      } catch (Exception e) {
+        logger.debug("validating {} threw unexpected exception", conn, e);
+      }
+      return validateResult != null && validateResult.booleanValue();
+    };
   }
 
 

--- a/core/src/main/java/org/ldaptive/ConnectionValidator.java
+++ b/core/src/main/java/org/ldaptive/ConnectionValidator.java
@@ -2,7 +2,9 @@
 package org.ldaptive;
 
 import java.time.Duration;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Provides an interface for defining connection validation.
@@ -11,6 +13,27 @@ import java.util.function.Function;
  */
 public interface ConnectionValidator extends Function<Connection, Boolean>
 {
+
+
+  /**
+   * Provides an asynchronous implementation of {@link #apply(Object)}. The supplied consumer will be invoked with the
+   * validation result. {@link #getValidateTimeout()} must be enforced by the caller.
+   *
+   * @param  conn  to validate
+   * @param  function  to consume the validation result
+   */
+  void applyAsync(Connection conn, Consumer<Boolean> function);
+
+
+  /**
+   * Provides an asynchronous implementation of {@link #apply(Object)}. The returned supplier will block until a
+   * validation result is received respecting {@link #getValidateTimeout()}.
+   *
+   * @param  conn  to validate
+   *
+   * @return  supplier to retrieve the validation result
+   */
+  Supplier<Boolean> applyAsync(Connection conn);
 
 
   /**

--- a/core/src/main/java/org/ldaptive/transport/netty/NettyConnection.java
+++ b/core/src/main/java/org/ldaptive/transport/netty/NettyConnection.java
@@ -14,6 +14,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1587,21 +1588,27 @@ public final class NettyConnection extends TransportConnection
     @Override
     public void channelActive(final ChannelHandlerContext ctx)
     {
+      // this implementation could also be done with user events
+      // while that may be cleaner it does introduce a dependency on the message thread pool which should be avoided
       LOGGER.trace("channel active on {}", ctx);
       sf = ctx.executor().scheduleAtFixedRate(
         () -> {
-          final java.util.concurrent.Future<Boolean> f = connectionExecutor.submit(
-            () -> connectionValidator.apply(NettyConnection.this));
-          boolean success = false;
-          try {
-            success = f.get(connectionValidator.getValidateTimeout().toMillis(), TimeUnit.MILLISECONDS);
-          } catch (Exception e) {
-            LOGGER.debug("validating {} threw unexpected exception", NettyConnection.this, e);
-          }
-          if (!success) {
-            ctx.fireExceptionCaught(
-              new LdapException(ResultCode.SERVER_DOWN, "Connection validation failed for " + NettyConnection.this));
-          }
+          final AtomicReference<Boolean> result = new AtomicReference<>();
+          ctx.executor().submit(() -> connectionValidator.applyAsync(NettyConnection.this, result::set));
+          ctx.executor().schedule(
+            () -> {
+              final boolean success = result.updateAndGet(b -> b == null ? false : b);
+              LOGGER.trace("connection validation returned {} for {}", success, NettyConnection.this);
+              if (!success) {
+                ctx.fireExceptionCaught(
+                  new LdapException(
+                    ResultCode.SERVER_DOWN,
+                    "Connection validation failed for " + NettyConnection.this));
+              }
+            },
+            Duration.ZERO.equals(connectionValidator.getValidateTimeout()) ?
+              connectionConfig.getResponseTimeout().toMillis() : connectionValidator.getValidateTimeout().toMillis(),
+            TimeUnit.MILLISECONDS);
         },
         connectionValidator.getValidatePeriod().toMillis(),
         connectionValidator.getValidatePeriod().toMillis(),

--- a/core/src/main/java/org/ldaptive/transport/netty/NettyConnection.java
+++ b/core/src/main/java/org/ldaptive/transport/netty/NettyConnection.java
@@ -1597,8 +1597,8 @@ public final class NettyConnection extends TransportConnection
           ctx.executor().submit(() -> connectionValidator.applyAsync(NettyConnection.this, result::set));
           ctx.executor().schedule(
             () -> {
+              LOGGER.trace("connection validation returned {} for {}", result.get(), NettyConnection.this);
               final boolean success = result.updateAndGet(b -> b == null ? false : b);
-              LOGGER.trace("connection validation returned {} for {}", success, NettyConnection.this);
               if (!success) {
                 ctx.fireExceptionCaught(
                   new LdapException(

--- a/core/src/test/java/org/ldaptive/PooledConnectionFactoryTest.java
+++ b/core/src/test/java/org/ldaptive/PooledConnectionFactoryTest.java
@@ -2,8 +2,10 @@
 package org.ldaptive;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -41,6 +43,7 @@ public class PooledConnectionFactoryTest
         factory.initialize();
       } finally {
         factory.close();
+        Assert.assertEquals(factory.availableCount(), 0);
       }
     } finally {
       server.stop();
@@ -109,6 +112,141 @@ public class PooledConnectionFactoryTest
         if (factory.isInitialized()) {
           factory.close();
         }
+        Assert.assertEquals(factory.availableCount() + factory.activeCount(), 0);
+      }
+    } finally {
+      server.stop();
+    }
+  }
+
+
+  /**
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "netty")
+  public void validatePeriodically()
+    throws Exception
+  {
+    final SimpleNettyServer server = new SimpleNettyServer();
+    try {
+      final InetSocketAddress address = server.start();
+      final PooledConnectionFactory factory = PooledConnectionFactory.builder()
+        .config(ConnectionConfig.builder()
+          .url(new LdapURL(address.getHostName(), address.getPort()).getHostnameWithSchemeAndPort())
+          .build())
+        .validator(SearchConnectionValidator.builder()
+          .build())
+        .build();
+      try {
+        factory.initialize();
+        Assert.assertEquals(factory.availableCount(), 3);
+        factory.validate();
+        Assert.assertEquals(factory.availableCount(), 3);
+      } finally {
+        factory.close();
+        Assert.assertEquals(factory.availableCount() + factory.activeCount(), 0);
+      }
+    } finally {
+      server.stop();
+    }
+  }
+
+
+  /**
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "netty")
+  public void validatePeriodicallyRestart()
+    throws Exception
+  {
+    final SimpleNettyServer server = new SimpleNettyServer();
+    try {
+      final InetSocketAddress address = server.start();
+      final PooledConnectionFactory factory = PooledConnectionFactory.builder()
+        .config(ConnectionConfig.builder()
+          .url(new LdapURL(address.getHostName(), address.getPort()).getHostnameWithSchemeAndPort())
+          .build())
+        .validator(SearchConnectionValidator.builder()
+          .build())
+        .build();
+      try {
+        factory.initialize();
+        Assert.assertEquals(factory.availableCount(), 3);
+        server.stop();
+        factory.validate();
+        Assert.assertEquals(factory.availableCount() + factory.activeCount(), 0);
+        server.start();
+        factory.validate();
+        Assert.assertEquals(factory.availableCount(), 3);
+      } finally {
+        factory.close();
+        Assert.assertEquals(factory.availableCount() + factory.activeCount(), 0);
+      }
+    } finally {
+      server.stop();
+    }
+  }
+
+
+  /**
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "netty")
+  public void validatePeriodicallyWithTimeout()
+    throws Exception
+  {
+    final AtomicReference<Duration> serverWait = new AtomicReference<>(Duration.ofSeconds(30));
+    final SimpleNettyServer server = new SimpleNettyServer(
+      null,
+      (ctx, msg) -> {
+        if (msg instanceof SearchRequest) {
+          try {
+            Thread.sleep(serverWait.get().toMillis());
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+          ctx.channel().writeAndFlush(SearchResponse.builder()
+            .messageID(1)
+            .resultCode(ResultCode.SUCCESS)
+            .build());
+        }
+      },
+      null);
+    try {
+      final InetSocketAddress address = server.start();
+      final PooledConnectionFactory factory = PooledConnectionFactory.builder()
+        .config(ConnectionConfig.builder()
+          .url(new LdapURL(address.getHostName(), address.getPort()).getHostnameWithSchemeAndPort())
+          .build())
+        .min(0)
+        .validator(SearchConnectionValidator.builder()
+          .timeout(Duration.ofSeconds(1))
+          .build())
+        .build();
+      try {
+        factory.initialize();
+        Assert.assertEquals(factory.availableCount(), 0);
+        // get 2 connections to grow the pool size and then validate
+        Connection c1 = factory.getConnection();
+        Connection c2 = factory.getConnection();
+        c1.close();
+        c2.close();
+        Assert.assertEquals(factory.availableCount(), 2);
+        factory.validate();
+        Assert.assertEquals(factory.availableCount(), 0);
+
+        // change the wait time and repeat
+        serverWait.set(Duration.ofMillis(500));
+        c1 = factory.getConnection();
+        c2 = factory.getConnection();
+        c1.close();
+        c2.close();
+        Assert.assertEquals(factory.availableCount(), 2);
+        factory.validate();
+        Assert.assertEquals(factory.availableCount(), 2);
+      } finally {
+        factory.close();
+        Assert.assertEquals(factory.availableCount() + factory.activeCount(), 0);
       }
     } finally {
       server.stop();

--- a/integration/src/test/java/org/ldaptive/ConnectionTest.java
+++ b/integration/src/test/java/org/ldaptive/ConnectionTest.java
@@ -2,6 +2,7 @@
 package org.ldaptive;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import org.ldaptive.ssl.AllowAnyHostnameVerifier;
 import org.ldaptive.ssl.AllowAnyTrustManager;
 import org.ldaptive.ssl.CustomTrustManager;
@@ -208,6 +209,150 @@ public class ConnectionTest
       conn.open();
     } finally {
       conn.close();
+    }
+  }
+
+
+  /** @throws  Exception  On test failure. */
+  @Test(groups = "conn")
+  public void validateConnectionDefaultSearch()
+    throws Exception
+  {
+    final ConnectionConfig cc = TestUtils.readConnectionConfig("classpath:/org/ldaptive/ldap.conn.properties");
+    cc.setConnectionValidator(SearchConnectionValidator.builder()
+      .timeout(Duration.ofSeconds(3))
+      .period(Duration.ofSeconds(5))
+      .build());
+    final DefaultConnectionFactory connFactory = new DefaultConnectionFactory(cc);
+
+    final Connection conn = connFactory.getConnection();
+    try {
+      conn.open();
+      conn.operation(SearchRequest.objectScopeSearchRequest("")).execute();
+      Thread.sleep(Duration.ofSeconds(15).toMillis());
+      conn.operation(SearchRequest.objectScopeSearchRequest("")).execute();
+    } finally {
+      conn.close();
+    }
+  }
+
+
+  /** @throws  Exception  On test failure. */
+  @Test(groups = "conn")
+  public void validateConnectionSingleSearch()
+    throws Exception
+  {
+    final ConnectionConfig cc = TestUtils.readConnectionConfig("classpath:/org/ldaptive/ldap.conn.properties");
+    cc.setConnectionValidator(SearchConnectionValidator.builder()
+      .timeout(Duration.ofSeconds(3))
+      .period(Duration.ofSeconds(5))
+      .build());
+    final SingleConnectionFactory connFactory = new SingleConnectionFactory(cc);
+    connFactory.initialize();
+
+    final Connection conn = connFactory.getConnection();
+    try {
+      conn.operation(SearchRequest.objectScopeSearchRequest("")).execute();
+      Thread.sleep(Duration.ofSeconds(15).toMillis());
+      conn.operation(SearchRequest.objectScopeSearchRequest("")).execute();
+    } finally {
+      connFactory.close();
+    }
+  }
+
+
+  /** @throws  Exception  On test failure. */
+  @Test(groups = "conn")
+  public void validateConnectionPooledSearch()
+    throws Exception
+  {
+    final ConnectionConfig cc = TestUtils.readConnectionConfig("classpath:/org/ldaptive/ldap.conn.properties");
+    cc.setConnectionValidator(SearchConnectionValidator.builder()
+      .timeout(Duration.ofSeconds(3))
+      .period(Duration.ofSeconds(5))
+      .build());
+    final PooledConnectionFactory connFactory = new PooledConnectionFactory(cc);
+    connFactory.initialize();
+
+    final Connection conn = connFactory.getConnection();
+    try {
+      conn.operation(SearchRequest.objectScopeSearchRequest("")).execute();
+      Thread.sleep(Duration.ofSeconds(15).toMillis());
+      conn.operation(SearchRequest.objectScopeSearchRequest("")).execute();
+    } finally {
+      connFactory.close();
+    }
+  }
+
+
+  /** @throws  Exception  On test failure. */
+  @Test(groups = "conn")
+  public void validateConnectionDefaultCompare()
+    throws Exception
+  {
+    final ConnectionConfig cc = TestUtils.readConnectionConfig("classpath:/org/ldaptive/ldap.conn.properties");
+    cc.setConnectionValidator(CompareConnectionValidator.builder()
+      .timeout(Duration.ofSeconds(3))
+      .period(Duration.ofSeconds(5))
+      .build());
+    final DefaultConnectionFactory connFactory = new DefaultConnectionFactory(cc);
+
+    final Connection conn = connFactory.getConnection();
+    try {
+      conn.open();
+      conn.operation(SearchRequest.objectScopeSearchRequest("")).execute();
+      Thread.sleep(Duration.ofSeconds(15).toMillis());
+      conn.operation(SearchRequest.objectScopeSearchRequest("")).execute();
+    } finally {
+      conn.close();
+    }
+  }
+
+
+  /** @throws  Exception  On test failure. */
+  @Test(groups = "conn")
+  public void validateConnectionSingleCompare()
+    throws Exception
+  {
+    final ConnectionConfig cc = TestUtils.readConnectionConfig("classpath:/org/ldaptive/ldap.conn.properties");
+    cc.setConnectionValidator(CompareConnectionValidator.builder()
+      .timeout(Duration.ofSeconds(3))
+      .period(Duration.ofSeconds(5))
+      .build());
+    final SingleConnectionFactory connFactory = new SingleConnectionFactory(cc);
+    connFactory.initialize();
+
+    final Connection conn = connFactory.getConnection();
+    try {
+      conn.operation(SearchRequest.objectScopeSearchRequest("")).execute();
+      Thread.sleep(Duration.ofSeconds(15).toMillis());
+      conn.operation(SearchRequest.objectScopeSearchRequest("")).execute();
+    } finally {
+      connFactory.close();
+    }
+  }
+
+
+  /** @throws  Exception  On test failure. */
+  @Test(groups = "conn")
+  public void validateConnectionPooledCompare()
+    throws Exception
+  {
+    final ConnectionConfig cc = TestUtils.readConnectionConfig("classpath:/org/ldaptive/ldap.conn.properties");
+    cc.setConnectionValidator(CompareConnectionValidator.builder()
+      .timeout(Duration.ofSeconds(3))
+      .period(Duration.ofSeconds(5))
+      .build());
+    final PooledConnectionFactory connFactory = new PooledConnectionFactory(cc);
+    connFactory.initialize();
+
+    final Connection conn = connFactory.getConnection();
+    try {
+      conn.operation(SearchRequest.objectScopeSearchRequest("")).execute();
+      Thread.sleep(Duration.ofSeconds(15).toMillis());
+      conn.operation(SearchRequest.objectScopeSearchRequest("")).execute();
+    } finally {
+      connFactory.close();
     }
   }
 


### PR DESCRIPTION
There are currently 3 distinct use cases for connection validation.
Validating a single connection and waiting for a result.
Validating a single connection without blocking.
Validating multiple connections all at the same time where the operation is async but the results are waited on.

This patch adds two methods to ConnectionValidator called #applyAsync to meet these use cases.
I would have preferred a single method, but this strategy affords a lot of flexibility.
These API changes made the validation code in AbstractConnectionPool much cleaner, eliminating the need for a cached thread pool.
Another ancillary benefit is that the #apply method now enforces the timeout, it no longer needs to be implemented by the invoker.

See #188