### PR TITLE
Add support for building a DNS name from a DN.

### DIFF
--- a/core/src/main/java/org/ldaptive/LdapURL.java
+++ b/core/src/main/java/org/ldaptive/LdapURL.java
@@ -108,11 +108,11 @@ public class LdapURL
 
 
   /**
-   * Creates a new entry.
+   * Creates a new ldap url.
    *
-   * @param  scheme  entryScheme
-   * @param  hostname  entryHostname
-   * @param  port  entryPort
+   * @param  scheme  url scheme
+   * @param  hostname  url hostname
+   * @param  port  url port
    * @param  baseDn  base DN
    * @param  attributes  attributes
    * @param  scope  search scope
@@ -141,9 +141,9 @@ public class LdapURL
 
 
   /**
-   * Returns the entryScheme.
+   * Returns the scheme.
    *
-   * @return  entryScheme
+   * @return  scheme
    */
   public String getScheme()
   {
@@ -152,9 +152,9 @@ public class LdapURL
 
 
   /**
-   * Returns the entryHostname.
+   * Returns the hostname.
    *
-   * @return  entryHostname
+   * @return  hostname
    */
   public String getHostname()
   {
@@ -163,9 +163,9 @@ public class LdapURL
 
 
   /**
-   * Returns the entryPort.
+   * Returns the port. If no port was supplied, returns the default port for the scheme.
    *
-   * @return  entryPort
+   * @return  port
    */
   public int getPort()
   {
@@ -177,9 +177,9 @@ public class LdapURL
 
 
   /**
-   * Returns whether a port was supplied in this entry.
+   * Returns false if a port was supplied in this url.
    *
-   * @return  whether a port was supplied in this entry
+   * @return  false if a port was supplied in this url
    */
   public boolean isDefaultPort()
   {
@@ -199,9 +199,9 @@ public class LdapURL
 
 
   /**
-   * Returns whether a base DN was supplied in this entry.
+   * Returns whether a base DN was supplied in this url.
    *
-   * @return  whether a base DN was supplied in this entry
+   * @return  whether a base DN was supplied in this url
    */
   public boolean isDefaultBaseDn()
   {
@@ -221,9 +221,9 @@ public class LdapURL
 
 
   /**
-   * Returns whether attributes were supplied in this entry.
+   * Returns whether attributes were supplied in this url.
    *
-   * @return  whether a attributes were supplied in this entry
+   * @return  whether a attributes were supplied in this url
    */
   public boolean isDefaultAttributes()
   {
@@ -243,9 +243,9 @@ public class LdapURL
 
 
   /**
-   * Returns whether a scope was supplied in this entry.
+   * Returns whether a scope was supplied in this url.
    *
-   * @return  whether a scope was supplied in this entry
+   * @return  whether a scope was supplied in this url
    */
   public boolean isDefaultScope()
   {
@@ -265,9 +265,9 @@ public class LdapURL
 
 
   /**
-   * Returns whether a filter was supplied in this entry.
+   * Returns whether a filter was supplied in this url.
    *
-   * @return  whether a filter was supplied in this entry
+   * @return  whether a filter was supplied in this url
    */
   public boolean isDefaultFilter()
   {

--- a/core/src/main/java/org/ldaptive/dns/DNSDomainFunction.java
+++ b/core/src/main/java/org/ldaptive/dns/DNSDomainFunction.java
@@ -1,0 +1,40 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.dns;
+
+import java.util.function.Function;
+import org.ldaptive.dn.Dn;
+import org.ldaptive.dn.RDn;
+
+/**
+ * Maps a DN to a domain name using the process described in
+ * <a href="https://datatracker.ietf.org/doc/html/draft-ietf-ldapext-locate-08">draft-ietf-ldapext-locate</a>
+ *
+ * @author  Middleware Services
+ */
+public class DNSDomainFunction implements Function<Dn, String>
+{
+
+
+  @Override
+  public String apply(final Dn dn)
+  {
+    final StringBuilder domain = new StringBuilder();
+    for (RDn rdn : dn.getRDns()) {
+      if (rdn.size() == 1 && rdn.getNameValue().hasName("DC")) {
+        final String attrValue = rdn.getNameValue().getAttributeValue();
+        // ignore empty DC components or any component containing a single dot
+        if (attrValue != null && !attrValue.isEmpty() && !".".equals(attrValue)) {
+          if (domain.length() > 0) {
+            domain.append('.');
+          }
+          domain.append(attrValue);
+        }
+      } else if (domain.length() > 0) {
+        // clear the domain if anything other than a single value, DC component is encountered
+        // this enforces that the DC components used must be at the end of the RDN sequence
+        domain.setLength(0);
+      }
+    }
+    return domain.toString();
+  }
+}

--- a/core/src/test/java/org/ldaptive/DnsSrvConnectionStrategyTest.java
+++ b/core/src/test/java/org/ldaptive/DnsSrvConnectionStrategyTest.java
@@ -75,6 +75,18 @@ public class DnsSrvConnectionStrategyTest
 
 
   /**
+   * Unit test for {@link DnsSrvConnectionStrategy#parseUrl(String)}.
+   */
+  @Test
+  public void parseLdapUrl()
+  {
+    final DnsSrvConnectionStrategy strategy = new DnsSrvConnectionStrategy();
+    Assert.assertEquals(
+      strategy.parseUrl("ldap:///DC=mycompany,DC=org"), new String[] {null, "_ldap._tcp.mycompany.org"});
+  }
+
+
+  /**
    * Unit test for {@link DnsSrvConnectionStrategy#iterator()}.
    */
   @Test

--- a/core/src/test/java/org/ldaptive/dns/DNSDomainFunctionTest.java
+++ b/core/src/test/java/org/ldaptive/dns/DNSDomainFunctionTest.java
@@ -1,0 +1,74 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.dns;
+
+import org.ldaptive.dn.Dn;
+import org.ldaptive.dn.NameValue;
+import org.ldaptive.dn.RDn;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@link DNSDomainFunction}.
+ *
+ * @author  Middleware Services
+ */
+public class DNSDomainFunctionTest
+{
+
+
+  /**
+   * DN test data.
+   *
+   * @return  test data
+   */
+  @DataProvider(name = "DNs")
+  public Object[][] createDNs()
+  {
+    return
+      new Object[][]{
+        new Object[]{
+          Dn.builder().add("cn=John Doe").add("ou=accounting").add("dc=example").add("dc=net").build(),
+          "example.net",
+        },
+        new Object[]{
+          Dn.builder().add("DC=ldaptive").add("DC=org").build(),
+          "ldaptive.org",
+        },
+        new Object[]{
+          Dn.builder().add("DC=ldap").add("ou=example").add("DC=ldaptive").add("DC=org").build(),
+          "ldaptive.org",
+        },
+        new Object[]{
+          Dn.builder()
+            .add("CN=test")
+            .add(new RDn(new NameValue("DC", "ldap1"), new NameValue("DC", "ldap2")))
+            .add("DC=ldaptive")
+            .add("DC=org").build(),
+          "ldaptive.org",
+        },
+        new Object[]{
+          Dn.builder().add("DC=ldap").add("DC=").add("DC=ldaptive").add("DC=org").build(),
+          "ldap.ldaptive.org",
+        },
+        new Object[]{
+          Dn.builder().add("DC=.").add("DC=ldap").add("DC=ldaptive").add("DC=org").build(),
+          "ldap.ldaptive.org",
+        },
+      };
+  }
+
+
+  /**
+   * @param  dn  DN to parse
+   * @param  domain  to match against
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(dataProvider = "DNs")
+  public void testApply(final Dn dn, final String domain)
+  {
+    final String dnDomain = new DNSDomainFunction().apply(dn);
+    Assert.assertEquals(dnDomain, domain);
+  }
+}


### PR DESCRIPTION
Add DNSDomainFunction which accepts a DN and returns a DNS name.
Update DnsSrvConnectionStrategy to leverage this behavior when it's provided an ldap URL.
See #203.