### PR TITLE
Set Automatic-Module-Name attributes in MANIFEST.MF

### DIFF
--- a/beans/pom.xml
+++ b/beans/pom.xml
@@ -48,5 +48,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <build>
+  	<plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.ldaptive.beans</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+  	</plugins>
+  </build>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,5 +46,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <build>
+  	<plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.ldaptive.core</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+  	</plugins>
+  </build>
 
 </project>

--- a/jdk8/beans/pom.xml
+++ b/jdk8/beans/pom.xml
@@ -80,6 +80,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.ldaptive.beans</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/jdk8/core/pom.xml
+++ b/jdk8/core/pom.xml
@@ -100,6 +100,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.ldaptive.core</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/jdk8/json/pom.xml
+++ b/jdk8/json/pom.xml
@@ -64,6 +64,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.ldaptive.json</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/jdk8/templates/pom.xml
+++ b/jdk8/templates/pom.xml
@@ -74,6 +74,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.ldaptive.templates</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -32,5 +32,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <build>
+  	<plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.ldaptive.json</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+  	</plugins>
+  </build>
 
 </project>

--- a/templates/pom.xml
+++ b/templates/pom.xml
@@ -40,5 +40,21 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <build>
+  	<plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.ldaptive.templates</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+  	</plugins>
+  </build>
 
 </project>


### PR DESCRIPTION
Fix #212 

I've updated the `pom.xml` to add the `Automatic-Module-Name` attribute in the `MANIFEST.MF` files

We should now have the following Java automatic modules:

- `org.ldaptive.beans`
- `org.ldaptive.core`
- `org.ldaptive.json`
- `org.ldaptive.templates`

