### PR TITLE
Refactor merge to support operation config.

### DIFF
--- a/core/src/main/java/org/ldaptive/AddOperation.java
+++ b/core/src/main/java/org/ldaptive/AddOperation.java
@@ -118,6 +118,29 @@ public class AddOperation extends AbstractOperation<AddRequest, AddResponse>
 
 
   /**
+   * Returns a new add operation with the same properties as the supplied operation.
+   *
+   * @param  operation  to copy
+   *
+   * @return  copy of the supplied add operation
+   */
+  public static AddOperation copy(final AddOperation operation)
+  {
+    final AddOperation op = new AddOperation();
+    op.setRequestHandlers(operation.getRequestHandlers());
+    op.setResultHandlers(operation.getResultHandlers());
+    op.setControlHandlers(operation.getControlHandlers());
+    op.setReferralHandlers(operation.getReferralHandlers());
+    op.setIntermediateResponseHandlers(operation.getIntermediateResponseHandlers());
+    op.setExceptionHandler(operation.getExceptionHandler());
+    op.setThrowCondition(operation.getThrowCondition());
+    op.setUnsolicitedNotificationHandlers(operation.getUnsolicitedNotificationHandlers());
+    op.setConnectionFactory(operation.getConnectionFactory());
+    return op;
+  }
+
+
+  /**
    * Creates a builder for this class.
    *
    * @return  new builder

--- a/core/src/main/java/org/ldaptive/BindOperation.java
+++ b/core/src/main/java/org/ldaptive/BindOperation.java
@@ -118,6 +118,29 @@ public class BindOperation extends AbstractOperation<BindRequest, BindResponse>
 
 
   /**
+   * Returns a new bind operation with the same properties as the supplied operation.
+   *
+   * @param  operation  to copy
+   *
+   * @return  copy of the supplied bind operation
+   */
+  public static BindOperation copy(final BindOperation operation)
+  {
+    final BindOperation op = new BindOperation();
+    op.setRequestHandlers(operation.getRequestHandlers());
+    op.setResultHandlers(operation.getResultHandlers());
+    op.setControlHandlers(operation.getControlHandlers());
+    op.setReferralHandlers(operation.getReferralHandlers());
+    op.setIntermediateResponseHandlers(operation.getIntermediateResponseHandlers());
+    op.setExceptionHandler(operation.getExceptionHandler());
+    op.setThrowCondition(operation.getThrowCondition());
+    op.setUnsolicitedNotificationHandlers(operation.getUnsolicitedNotificationHandlers());
+    op.setConnectionFactory(operation.getConnectionFactory());
+    return op;
+  }
+
+
+  /**
    * Creates a builder for this class.
    *
    * @return  new builder

--- a/core/src/main/java/org/ldaptive/CompareOperation.java
+++ b/core/src/main/java/org/ldaptive/CompareOperation.java
@@ -154,6 +154,30 @@ public class CompareOperation extends AbstractOperation<CompareRequest, CompareR
   }
 
 
+  /**
+   * Returns a new compare operation with the same properties as the supplied operation.
+   *
+   * @param  operation  to copy
+   *
+   * @return  copy of the supplied compare operation
+   */
+  public static CompareOperation copy(final CompareOperation operation)
+  {
+    final CompareOperation op = new CompareOperation();
+    op.setRequestHandlers(operation.getRequestHandlers());
+    op.setResultHandlers(operation.getResultHandlers());
+    op.setControlHandlers(operation.getControlHandlers());
+    op.setReferralHandlers(operation.getReferralHandlers());
+    op.setIntermediateResponseHandlers(operation.getIntermediateResponseHandlers());
+    op.setExceptionHandler(operation.getExceptionHandler());
+    op.setThrowCondition(operation.getThrowCondition());
+    op.setUnsolicitedNotificationHandlers(operation.getUnsolicitedNotificationHandlers());
+    op.setConnectionFactory(operation.getConnectionFactory());
+    op.setCompareValueHandlers(operation.getCompareValueHandlers());
+    return op;
+  }
+
+
   @Override
   public String toString()
   {

--- a/core/src/main/java/org/ldaptive/DeleteOperation.java
+++ b/core/src/main/java/org/ldaptive/DeleteOperation.java
@@ -118,6 +118,29 @@ public class DeleteOperation extends AbstractOperation<DeleteRequest, DeleteResp
 
 
   /**
+   * Returns a new delete operation with the same properties as the supplied operation.
+   *
+   * @param  operation  to copy
+   *
+   * @return  copy of the supplied delete operation
+   */
+  public static DeleteOperation copy(final DeleteOperation operation)
+  {
+    final DeleteOperation op = new DeleteOperation();
+    op.setRequestHandlers(operation.getRequestHandlers());
+    op.setResultHandlers(operation.getResultHandlers());
+    op.setControlHandlers(operation.getControlHandlers());
+    op.setReferralHandlers(operation.getReferralHandlers());
+    op.setIntermediateResponseHandlers(operation.getIntermediateResponseHandlers());
+    op.setExceptionHandler(operation.getExceptionHandler());
+    op.setThrowCondition(operation.getThrowCondition());
+    op.setUnsolicitedNotificationHandlers(operation.getUnsolicitedNotificationHandlers());
+    op.setConnectionFactory(operation.getConnectionFactory());
+    return op;
+  }
+
+
+  /**
    * Creates a builder for this class.
    *
    * @return  new builder

--- a/core/src/main/java/org/ldaptive/ModifyDnOperation.java
+++ b/core/src/main/java/org/ldaptive/ModifyDnOperation.java
@@ -117,6 +117,29 @@ public class ModifyDnOperation extends AbstractOperation<ModifyDnRequest, Modify
 
 
   /**
+   * Returns a new modify dn operation with the same properties as the supplied operation.
+   *
+   * @param  operation  to copy
+   *
+   * @return  copy of the supplied modify dn operation
+   */
+  public static ModifyDnOperation copy(final ModifyDnOperation operation)
+  {
+    final ModifyDnOperation op = new ModifyDnOperation();
+    op.setRequestHandlers(operation.getRequestHandlers());
+    op.setResultHandlers(operation.getResultHandlers());
+    op.setControlHandlers(operation.getControlHandlers());
+    op.setReferralHandlers(operation.getReferralHandlers());
+    op.setIntermediateResponseHandlers(operation.getIntermediateResponseHandlers());
+    op.setExceptionHandler(operation.getExceptionHandler());
+    op.setThrowCondition(operation.getThrowCondition());
+    op.setUnsolicitedNotificationHandlers(operation.getUnsolicitedNotificationHandlers());
+    op.setConnectionFactory(operation.getConnectionFactory());
+    return op;
+  }
+
+
+  /**
    * Creates a builder for this class.
    *
    * @return  new builder

--- a/core/src/main/java/org/ldaptive/ModifyOperation.java
+++ b/core/src/main/java/org/ldaptive/ModifyOperation.java
@@ -117,6 +117,29 @@ public class ModifyOperation extends AbstractOperation<ModifyRequest, ModifyResp
 
 
   /**
+   * Returns a new modify operation with the same properties as the supplied operation.
+   *
+   * @param  operation  to copy
+   *
+   * @return  copy of the supplied modify operation
+   */
+  public static ModifyOperation copy(final ModifyOperation operation)
+  {
+    final ModifyOperation op = new ModifyOperation();
+    op.setRequestHandlers(operation.getRequestHandlers());
+    op.setResultHandlers(operation.getResultHandlers());
+    op.setControlHandlers(operation.getControlHandlers());
+    op.setReferralHandlers(operation.getReferralHandlers());
+    op.setIntermediateResponseHandlers(operation.getIntermediateResponseHandlers());
+    op.setExceptionHandler(operation.getExceptionHandler());
+    op.setThrowCondition(operation.getThrowCondition());
+    op.setUnsolicitedNotificationHandlers(operation.getUnsolicitedNotificationHandlers());
+    op.setConnectionFactory(operation.getConnectionFactory());
+    return op;
+  }
+
+
+  /**
    * Creates a builder for this class.
    *
    * @return  new builder

--- a/core/src/main/java/org/ldaptive/SearchOperation.java
+++ b/core/src/main/java/org/ldaptive/SearchOperation.java
@@ -827,10 +827,10 @@ public class SearchOperation extends AbstractOperation<SearchRequest, SearchResp
     op.setExceptionHandler(operation.getExceptionHandler());
     op.setThrowCondition(operation.getThrowCondition());
     op.setUnsolicitedNotificationHandlers(operation.getUnsolicitedNotificationHandlers());
+    op.setConnectionFactory(operation.getConnectionFactory());
     op.setEntryHandlers(operation.getEntryHandlers());
     op.setReferenceHandlers(operation.getReferenceHandlers());
     op.setSearchResultHandlers(operation.getSearchResultHandlers());
-    op.setConnectionFactory(operation.getConnectionFactory());
     op.setRequest(operation.getRequest());
     op.setTemplate(operation.getTemplate());
     return op;

--- a/core/src/main/java/org/ldaptive/extended/ExtendedOperation.java
+++ b/core/src/main/java/org/ldaptive/extended/ExtendedOperation.java
@@ -159,6 +159,30 @@ public class ExtendedOperation extends AbstractOperation<ExtendedRequest, Extend
   }
 
 
+  /**
+   * Returns a new extended operation with the same properties as the supplied operation.
+   *
+   * @param  operation  to copy
+   *
+   * @return  copy of the supplied extended operation
+   */
+  public static ExtendedOperation copy(final ExtendedOperation operation)
+  {
+    final ExtendedOperation op = new ExtendedOperation();
+    op.setRequestHandlers(operation.getRequestHandlers());
+    op.setResultHandlers(operation.getResultHandlers());
+    op.setControlHandlers(operation.getControlHandlers());
+    op.setReferralHandlers(operation.getReferralHandlers());
+    op.setIntermediateResponseHandlers(operation.getIntermediateResponseHandlers());
+    op.setExceptionHandler(operation.getExceptionHandler());
+    op.setThrowCondition(operation.getThrowCondition());
+    op.setUnsolicitedNotificationHandlers(operation.getUnsolicitedNotificationHandlers());
+    op.setConnectionFactory(operation.getConnectionFactory());
+    op.setExtendedValueHandlers(operation.getExtendedValueHandlers());
+    return op;
+  }
+
+
   @Override
   public String toString()
   {


### PR DESCRIPTION
The underlying operations used by the merge operation can now be configured with handlers. Update MergeOperation to expose properties for these operations. Note that this is a behavioral change to the merge as the initial search is no longer guaranteed to occur on the same connection as the following operation. Add copy methods to each operation for consistency.