### PR TITLE
Add support for batching merge operations.

### DIFF
--- a/core/src/main/java/org/ldaptive/ext/MergeRequest.java
+++ b/core/src/main/java/org/ldaptive/ext/MergeRequest.java
@@ -27,6 +27,15 @@ public class MergeRequest
   /** Attribute names to exclude when performing a merge. */
   private String[] excludeAttrs;
 
+  /** Whether to use replace or add/delete for attribute modifications. */
+  private boolean useReplace = true;
+
+  /** Number of attribute modifications to batch together. */
+  private int modificationBatchSize;
+
+  /** Number of attribute values to batch together. */
+  private int attributeValuesBatchSize;
+
 
   /** Default constructor. */
   public MergeRequest() {}
@@ -166,6 +175,72 @@ public class MergeRequest
   }
 
 
+  /**
+   * Returns whether replace should be used for attribute modifications.
+   *
+   * @return  whether replace should be used for attribute modifications
+   */
+  public boolean isUseReplace()
+  {
+    return useReplace;
+  }
+
+
+  /**
+   * Sets whether replace should be used for attribute modifications.
+   *
+   * @param  replace  whether replace should be used for attribute modifications
+   */
+  public void setUseReplace(final boolean replace)
+  {
+    useReplace = replace;
+  }
+
+
+  /**
+   * Returns the number of modifications that a modify operation should contain.
+   *
+   * @return  number of modifications that a modify operation should contain
+   */
+  public int getModificationBatchSize()
+  {
+    return modificationBatchSize;
+  }
+
+
+  /**
+   * Sets the number of modifications that a modify operation should contain.
+   *
+   * @param  size  number of modifications that a modify operation should contain
+   */
+  public void setModificationBatchSize(final int size)
+  {
+    modificationBatchSize = size;
+  }
+
+
+  /**
+   * Returns the number of attribute values that any single attribute modification should contain.
+   *
+   * @return  number of attribute values that any single attribute modification should contain
+   */
+  public int getAttributeValuesBatchSize()
+  {
+    return attributeValuesBatchSize;
+  }
+
+
+  /**
+   * Sets the number of attribute values that any single attribute modification should contain.
+   *
+   * @param  size  number of attribute values that any single attribute modification should contain
+   */
+  public void setAttributeValuesBatchSize(final int size)
+  {
+    attributeValuesBatchSize = size;
+  }
+
+
   @Override
   public String toString()
   {
@@ -175,6 +250,9 @@ public class MergeRequest
       .append("deleteEntry=").append(deleteEntry).append(", ")
       .append("searchAttributes=").append(Arrays.toString(searchAttrs)).append(", ")
       .append("includeAttributes=").append(Arrays.toString(includeAttrs)).append(", ")
-      .append("excludeAttributes=").append(Arrays.toString(includeAttrs)).append("]").toString();
+      .append("excludeAttributes=").append(Arrays.toString(excludeAttrs)).append(", ")
+      .append("useReplace=").append(useReplace).append(", ")
+      .append("modificationBatchSize=").append(modificationBatchSize).append(", ")
+      .append("excludeAttributes=").append(attributeValuesBatchSize).append("]").toString();
   }
 }

--- a/integration/src/test/java/org/ldaptive/ext/MergeOperationTest.java
+++ b/integration/src/test/java/org/ldaptive/ext/MergeOperationTest.java
@@ -111,9 +111,113 @@ public class MergeOperationTest extends AbstractTest
     } else {
       request.setExcludeAttributes((String[]) null);
     }
+    // merge givenName and initials changes
     merge.execute(request);
-
     result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
     TestUtils.assertEquals(source, result.getEntry());
+
+    // delete mail attribute
+    final LdapAttribute mail = source.getAttribute("mail");
+    source.removeAttributes(mail);
+    merge.execute(request);
+    result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
+    TestUtils.assertEquals(source, result.getEntry());
+    Assert.assertNull(result.getEntry().getAttribute("mail"));
+
+    // add mail attribute
+    source.addAttributes(mail);
+    merge.execute(request);
+    result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
+    TestUtils.assertEquals(source, result.getEntry());
+    Assert.assertNotNull(result.getEntry().getAttribute("mail"));
+
+    // add new mail values using replace
+    mail.addStringValues(
+      "ccoolidge2@ldaptive.org", "ccoolidge3@ldaptive.org", "ccoolidge4@ldaptive.org", "ccoolidge5@ldaptive.org");
+    merge.execute(request);
+    result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
+    TestUtils.assertEquals(source, result.getEntry());
+    Assert.assertEquals(result.getEntry().getAttribute("mail").size(), 5);
+
+    // remove mail values using replace
+    mail.removeStringValues("ccoolidge4@ldaptive.org", "ccoolidge5@ldaptive.org");
+    merge.execute(request);
+    result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
+    TestUtils.assertEquals(source, result.getEntry());
+    Assert.assertEquals(result.getEntry().getAttribute("mail").size(), 3);
+
+    // add new mail value using add
+    request.setUseReplace(false);
+    mail.clear();
+    mail.addStringValues("ccoolidge@ldaptive.org");
+    merge.execute(request);
+    result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
+    TestUtils.assertEquals(source, result.getEntry());
+    Assert.assertEquals(result.getEntry().getAttribute("mail").size(), 1);
+
+    mail.addStringValues(
+      "ccoolidge2@ldaptive.org", "ccoolidge3@ldaptive.org", "ccoolidge4@ldaptive.org", "ccoolidge5@ldaptive.org");
+    merge.execute(request);
+    result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
+    TestUtils.assertEquals(source, result.getEntry());
+    Assert.assertEquals(result.getEntry().getAttribute("mail").size(), 5);
+
+    // remove mail values using delete
+    mail.removeStringValues("ccoolidge4@ldaptive.org", "ccoolidge5@ldaptive.org");
+    merge.execute(request);
+    result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
+    TestUtils.assertEquals(source, result.getEntry());
+    Assert.assertEquals(result.getEntry().getAttribute("mail").size(), 3);
+
+    // use batching
+    request.setAttributeValuesBatchSize(2);
+    request.setModificationBatchSize(1);
+    mail.addStringValues(
+      "ccoolidge4@ldaptive.org", "ccoolidge5@ldaptive.org", "ccoolidge6@ldaptive.org", "ccoolidge7@ldaptive.org",
+      "ccoolidge8@ldaptive.org", "ccoolidge9@ldaptive.org", "ccoolidge10@ldaptive.org", "ccoolidge11@ldaptive.org");
+    merge.execute(request);
+    result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
+    TestUtils.assertEquals(source, result.getEntry());
+    Assert.assertEquals(result.getEntry().getAttribute("mail").size(), 11);
+
+    request.setAttributeValuesBatchSize(2);
+    request.setModificationBatchSize(0);
+    mail.removeStringValues(
+      "ccoolidge4@ldaptive.org", "ccoolidge5@ldaptive.org", "ccoolidge6@ldaptive.org", "ccoolidge7@ldaptive.org",
+      "ccoolidge8@ldaptive.org", "ccoolidge9@ldaptive.org", "ccoolidge10@ldaptive.org", "ccoolidge11@ldaptive.org");
+    merge.execute(request);
+    result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
+    TestUtils.assertEquals(source, result.getEntry());
+    Assert.assertEquals(result.getEntry().getAttribute("mail").size(), 3);
+
+    request.setAttributeValuesBatchSize(0);
+    request.setModificationBatchSize(2);
+    mail.addStringValues(
+      "ccoolidge4@ldaptive.org", "ccoolidge5@ldaptive.org", "ccoolidge6@ldaptive.org", "ccoolidge7@ldaptive.org",
+      "ccoolidge8@ldaptive.org", "ccoolidge9@ldaptive.org", "ccoolidge10@ldaptive.org", "ccoolidge11@ldaptive.org");
+    merge.execute(request);
+    result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
+    TestUtils.assertEquals(source, result.getEntry());
+    Assert.assertEquals(result.getEntry().getAttribute("mail").size(), 11);
+
+    request.setAttributeValuesBatchSize(2);
+    request.setModificationBatchSize(10);
+    mail.removeStringValues(
+      "ccoolidge4@ldaptive.org", "ccoolidge5@ldaptive.org", "ccoolidge6@ldaptive.org", "ccoolidge7@ldaptive.org",
+      "ccoolidge8@ldaptive.org", "ccoolidge9@ldaptive.org", "ccoolidge10@ldaptive.org", "ccoolidge11@ldaptive.org");
+    merge.execute(request);
+    result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
+    TestUtils.assertEquals(source, result.getEntry());
+    Assert.assertEquals(result.getEntry().getAttribute("mail").size(), 3);
+
+    request.setAttributeValuesBatchSize(1);
+    request.setModificationBatchSize(10);
+    mail.addStringValues(
+      "ccoolidge4@ldaptive.org", "ccoolidge5@ldaptive.org", "ccoolidge6@ldaptive.org", "ccoolidge7@ldaptive.org",
+      "ccoolidge8@ldaptive.org", "ccoolidge9@ldaptive.org", "ccoolidge10@ldaptive.org", "ccoolidge11@ldaptive.org");
+    merge.execute(request);
+    result = search.execute(SearchRequest.objectScopeSearchRequest(source.getDn(), source.getAttributeNames()));
+    TestUtils.assertEquals(source, result.getEntry());
+    Assert.assertEquals(result.getEntry().getAttribute("mail").size(), 11);
   }
 }


### PR DESCRIPTION
Add a flag for controlling whether REPLACE is used versus ADD/DELETE in attribute modifications. Update MergeRequest to include properties for controlling both modification batch size and attribute value batch size. Update MergeOperation to process new MergeRequest properties. Note that the result of the merge operation when batching is now the result of the last operation performed.