### PR TITLE
Fix WARN logs

### DIFF
--- a/core/src/main/java/org/ldaptive/transport/GssApiSaslClient.java
+++ b/core/src/main/java/org/ldaptive/transport/GssApiSaslClient.java
@@ -87,7 +87,7 @@ public class GssApiSaslClient implements SaslClient<GssApiBindRequest>
         try {
           return conn.operation(request);
         } catch (Exception e) {
-          LOGGER.warn("SASL GSSAPI operation failed for {}", this, e);
+          LOGGER.warn("SASL GSSAPI operation failed for {} / exception: {}", this, e);
           doAsException[0] = e;
         }
         return null;

--- a/core/src/main/java/org/ldaptive/transport/netty/NettyConnection.java
+++ b/core/src/main/java/org/ldaptive/transport/netty/NettyConnection.java
@@ -1246,7 +1246,7 @@ public final class NettyConnection extends TransportConnection
       if (future.isSuccess()) {
         LOGGER.trace("operation channel success for {}", NettyConnection.this);
       } else {
-        LOGGER.warn("operation channel error for {}", NettyConnection.this, future.cause());
+        LOGGER.warn("operation channel error for {} / cause: {}", NettyConnection.this, future.cause());
       }
     }
   }
@@ -1282,7 +1282,7 @@ public final class NettyConnection extends TransportConnection
                 try {
                   reconnect();
                 } catch (Exception e) {
-                  LOGGER.warn("Reconnect attempt failed for {}", NettyConnection.this, e);
+                  LOGGER.warn("Reconnect attempt failed for {} / cause: {}", NettyConnection.this, e);
                 } finally {
                   reconnecting.set(false);
                 }
@@ -1652,7 +1652,7 @@ public final class NettyConnection extends TransportConnection
     @Override
     public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause)
     {
-      LOGGER.warn("Inbound handler caught exception for {}", NettyConnection.this, cause);
+      LOGGER.warn("Inbound handler caught exception for {} / cause: {}", NettyConnection.this, cause);
       inboundException = cause;
       if (channel != null && !isClosing()) {
         channel.close().addListener(new LogFutureListener());

--- a/core/src/main/java/org/ldaptive/transport/netty/NettyUtils.java
+++ b/core/src/main/java/org/ldaptive/transport/netty/NettyUtils.java
@@ -135,7 +135,7 @@ public final class NettyUtils
         shutdownLatch.countDown();
         if (!f.isSuccess()) {
           if (f.cause() != null) {
-            LOGGER.warn("Could not shutdown worker group {}", workerGroup, f.cause());
+            LOGGER.warn("Could not shutdown worker group {} / cause: {}", workerGroup, f.cause());
           } else {
             LOGGER.warn("Could not shutdown worker group {}", workerGroup);
           }


### PR DESCRIPTION
On a specific CAS server installation using LDAP via Ldaptive but where the `netty-common` JAR was missing, I have realized that the WARN logs displayed by `NettyConnection` did not output the cause (`java.lang.NoClassDefFoundError`).

This PR fixes the misdefined WARN calls.