### PR TITLE
Add timeoutIsFailure and validResultCodes.

### DIFF
--- a/core/src/main/java/org/ldaptive/AbstractOperationConnectionValidator.java
+++ b/core/src/main/java/org/ldaptive/AbstractOperationConnectionValidator.java
@@ -1,0 +1,177 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+/**
+ * Base class for validators that use an operation to perform validation. By default, validation is considered
+ * successful if the operation result contains any result code. Stricter validation can be configured by setting {@link
+ * #validResultCodes}.
+ *
+ * @param  <Q>  type of request
+ * @param  <S>  type of result
+ *
+ * @author  Middleware Services
+ */
+public abstract class AbstractOperationConnectionValidator<Q extends Request, S extends Result>
+  extends AbstractConnectionValidator
+{
+
+  /** Operation request. */
+  private Q request;
+
+  /** Valid result codes. */
+  private ResultCode[] validResultCodes;
+
+
+  /**
+   * Returns the operation request.
+   *
+   * @return  operation request
+   */
+  public Q getRequest()
+  {
+    return request;
+  }
+
+
+  /**
+   * Sets the operation request.
+   *
+   * @param  req  operation request
+   */
+  public void setRequest(final Q req)
+  {
+    request = req;
+  }
+
+
+  /**
+   * Returns the valid result codes.
+   *
+   * @return  valid result codes
+   */
+  public ResultCode[] getValidResultCodes()
+  {
+    return validResultCodes;
+  }
+
+
+  /**
+   * Sets the valid result codes.
+   *
+   * @param  codes  that represent a valid connection
+   */
+  public void setValidResultCodes(final ResultCode... codes)
+  {
+    validResultCodes = codes;
+  }
+
+
+  /**
+   * Perform the operation for this validator.
+   *
+   * @param  conn  to validate
+   *
+   * @return  operation handle
+   */
+  protected abstract OperationHandle<Q, S> performOperation(Connection conn);
+
+
+  @Override
+  public void applyAsync(final Connection conn, final Consumer<Boolean> function)
+  {
+    if (conn == null) {
+      function.accept(false);
+    } else {
+      final OperationHandle<Q, S> h = performOperation(conn);
+      h.onResult(r -> {
+        if (validResultCodes != null) {
+          function.accept(Arrays.stream(validResultCodes).anyMatch(rc -> rc.equals(r.getResultCode())));
+        } else {
+          function.accept(r.getResultCode() != null);
+        }
+      });
+      h.onException(e -> {
+        if (e != null && e.getResultCode() == ResultCode.LDAP_TIMEOUT && !getTimeoutIsFailure()) {
+          logger.debug("Connection validator timeout ignored for {}", conn);
+          function.accept(true);
+        } else {
+          logger.debug("Connection validator failed for {}", conn, e);
+          function.accept(false);
+        }
+      });
+      h.send();
+    }
+  }
+
+
+  @Override
+  public String toString()
+  {
+    return super.toString() + ", request=" + request + ", validResultCodes=" + Arrays.toString(validResultCodes);
+  }
+
+
+  /**
+   * Base class for operation validator builders.
+   *
+   * @param  <Q>  type of request
+   * @param  <S>  type of result
+   * @param  <B>  type of builder
+   * @param  <T>  type of validator
+   */
+  protected abstract static class AbstractBuilder
+    <Q extends Request, S extends Result, B, T extends AbstractOperationConnectionValidator<Q, S>> extends
+      AbstractConnectionValidator.AbstractBuilder<B, T>
+  {
+
+
+    /**
+     * Creates a new abstract builder.
+     *
+     * @param  t  validator to build
+     */
+    protected AbstractBuilder(final T t)
+    {
+      super(t);
+    }
+
+
+    /**
+     * Returns this builder.
+     *
+     * @return  builder
+     */
+    protected abstract B self();
+
+
+    /**
+     * Sets the request to use for validation.
+     *
+     * @param  request  operation request
+     *
+     * @return  this builder
+     */
+    public B request(final Q request)
+    {
+      object.setRequest(request);
+      return self();
+    }
+
+
+    /**
+     * Sets the result codes to use for validation.
+     *
+     * @param  codes  valid result codes
+     *
+     * @return  this builder
+     */
+    public B validResultCodes(final ResultCode... codes)
+    {
+      object.setValidResultCodes(codes);
+      return self();
+    }
+  }
+}

--- a/integration/src/test/java/org/ldaptive/CompareConnectionValidatorTest.java
+++ b/integration/src/test/java/org/ldaptive/CompareConnectionValidatorTest.java
@@ -79,4 +79,69 @@ public class CompareConnectionValidatorTest extends AbstractTest
     }
     Assert.assertFalse(validator.applyAsync(c).get());
   }
+
+
+  /**
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "validator")
+  public void validResultCodes()
+    throws Exception
+  {
+    final ConnectionFactory cf = TestUtils.createConnectionFactory();
+    CompareConnectionValidator validator = CompareConnectionValidator.builder()
+      .validResultCodes(ResultCode.AUTH_METHOD_NOT_SUPPORTED)
+      .timeout(Duration.ofSeconds(5))
+      .build();
+    try (Connection c = cf.getConnection()) {
+      c.open();
+      Assert.assertFalse(validator.apply(c));
+    }
+
+    validator = CompareConnectionValidator.builder()
+      .validResultCodes(ResultCode.COMPARE_TRUE)
+      .timeout(Duration.ofSeconds(5))
+      .build();
+    try (Connection c = cf.getConnection()) {
+      c.open();
+      Assert.assertTrue(validator.apply(c));
+    }
+
+    validator = CompareConnectionValidator.builder()
+      .validResultCodes(ResultCode.COMPARE_FALSE, ResultCode.COMPARE_TRUE)
+      .timeout(Duration.ofSeconds(5))
+      .build();
+    try (Connection c = cf.getConnection()) {
+      c.open();
+      Assert.assertTrue(validator.apply(c));
+    }
+  }
+
+
+  /**
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "validator")
+  public void timeoutIsFailure()
+    throws Exception
+  {
+    final ConnectionFactory cf = TestUtils.createConnectionFactory();
+    CompareConnectionValidator validator = CompareConnectionValidator.builder()
+      .timeout(Duration.ofNanos(100))
+      .timeoutIsFailure(false)
+      .build();
+    try (Connection c = cf.getConnection()) {
+      c.open();
+      Assert.assertTrue(validator.apply(c));
+    }
+
+    validator = CompareConnectionValidator.builder()
+      .timeout(Duration.ofNanos(100))
+      .timeoutIsFailure(true)
+      .build();
+    try (Connection c = cf.getConnection()) {
+      c.open();
+      Assert.assertFalse(validator.apply(c));
+    }
+  }
 }

--- a/integration/src/test/java/org/ldaptive/SearchConnectionValidatorTest.java
+++ b/integration/src/test/java/org/ldaptive/SearchConnectionValidatorTest.java
@@ -79,4 +79,69 @@ public class SearchConnectionValidatorTest extends AbstractTest
     }
     Assert.assertFalse(validator.applyAsync(c).get());
   }
+
+
+  /**
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "validator")
+  public void validResultCodes()
+    throws Exception
+  {
+    final ConnectionFactory cf = TestUtils.createConnectionFactory();
+    SearchConnectionValidator validator = SearchConnectionValidator.builder()
+      .validResultCodes(ResultCode.AUTH_METHOD_NOT_SUPPORTED)
+      .timeout(Duration.ofSeconds(5))
+      .build();
+    try (Connection c = cf.getConnection()) {
+      c.open();
+      Assert.assertFalse(validator.apply(c));
+    }
+
+    validator = SearchConnectionValidator.builder()
+      .validResultCodes(ResultCode.SUCCESS)
+      .timeout(Duration.ofSeconds(5))
+      .build();
+    try (Connection c = cf.getConnection()) {
+      c.open();
+      Assert.assertTrue(validator.apply(c));
+    }
+
+    validator = SearchConnectionValidator.builder()
+      .validResultCodes(ResultCode.PARTIAL_RESULTS, ResultCode.SUCCESS)
+      .timeout(Duration.ofSeconds(5))
+      .build();
+    try (Connection c = cf.getConnection()) {
+      c.open();
+      Assert.assertTrue(validator.apply(c));
+    }
+  }
+
+
+  /**
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "validator")
+  public void timeoutIsFailure()
+    throws Exception
+  {
+    final ConnectionFactory cf = TestUtils.createConnectionFactory();
+    SearchConnectionValidator validator = SearchConnectionValidator.builder()
+      .timeout(Duration.ofNanos(100))
+      .timeoutIsFailure(false)
+      .build();
+    try (Connection c = cf.getConnection()) {
+      c.open();
+      Assert.assertTrue(validator.apply(c));
+    }
+
+    validator = SearchConnectionValidator.builder()
+      .timeout(Duration.ofNanos(100))
+      .timeoutIsFailure(true)
+      .build();
+    try (Connection c = cf.getConnection()) {
+      c.open();
+      Assert.assertFalse(validator.apply(c));
+    }
+  }
 }


### PR DESCRIPTION
Update SearchConnectionValidator and CompareConnectionValidator to support new configuration options. timeoutIsFailure allows control over whether a connection timeout represents a validation failure. validResultCodes allows control over which result codes represent a validation success.