### PR TITLE
Change the behavior of response timeout.

### DIFF
--- a/core/src/main/java/org/ldaptive/AbstractRequestMessage.java
+++ b/core/src/main/java/org/ldaptive/AbstractRequestMessage.java
@@ -1,6 +1,7 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.ldaptive;
 
+import java.time.Duration;
 import java.util.Arrays;
 import org.ldaptive.asn1.BooleanType;
 import org.ldaptive.asn1.ConstructedDEREncoder;
@@ -39,6 +40,9 @@ public abstract class AbstractRequestMessage implements Request
   /** LDAP controls. */
   private RequestControl[] controls;
 
+  /** Duration of time to wait for a response. This property is not part of the request specification. */
+  private Duration responseTimeout;
+
 
   public RequestControl[] getControls()
   {
@@ -49,6 +53,31 @@ public abstract class AbstractRequestMessage implements Request
   public void setControls(final RequestControl... cntrls)
   {
     controls = cntrls;
+  }
+
+
+  /**
+   * Returns the response timeout.
+   *
+   * @return  timeout
+   */
+  public Duration getResponseTimeout()
+  {
+    return responseTimeout;
+  }
+
+
+  /**
+   * Sets the maximum amount of time to wait for a response from this request.
+   *
+   * @param  time  timeout for a response
+   */
+  public void setResponseTimeout(final Duration time)
+  {
+    if (time == null || time.isNegative()) {
+      throw new IllegalArgumentException("Response timeout cannot be null or negative");
+    }
+    responseTimeout = time;
   }
 
 
@@ -110,7 +139,9 @@ public abstract class AbstractRequestMessage implements Request
   @Override
   public String toString()
   {
-    return getClass().getName() + "@" + hashCode() + "::" + "controls=" + Arrays.toString(controls);
+    return getClass().getName() + "@" + hashCode() + "::" +
+      "controls=" + Arrays.toString(controls) + ", " +
+      "responseTimeout=" + responseTimeout;
   }
 
 
@@ -156,6 +187,20 @@ public abstract class AbstractRequestMessage implements Request
     public B controls(final RequestControl... cntrls)
     {
       object.setControls(cntrls);
+      return self();
+    }
+
+
+    /**
+     * Sets the response timeout on the message.
+     *
+     * @param  time  response timeout
+     *
+     * @return  this builder
+     */
+    public B responseTimeout(final Duration time)
+    {
+      object.setResponseTimeout(time);
       return self();
     }
 

--- a/core/src/main/java/org/ldaptive/SearchRequest.java
+++ b/core/src/main/java/org/ldaptive/SearchRequest.java
@@ -522,7 +522,8 @@ public class SearchRequest extends AbstractRequestMessage
         LdapUtils.areEqual(searchFilter, v.searchFilter) &&
         LdapUtils.areEqual(returnAttributes, v.returnAttributes) &&
         LdapUtils.areEqual(binaryAttributes, v.binaryAttributes) &&
-        LdapUtils.areEqual(getControls(), v.getControls());
+        LdapUtils.areEqual(getControls(), v.getControls()) &&
+        LdapUtils.areEqual(getResponseTimeout(), v.getResponseTimeout());
     }
     return false;
   }
@@ -543,7 +544,8 @@ public class SearchRequest extends AbstractRequestMessage
         searchFilter,
         returnAttributes,
         binaryAttributes,
-        getControls());
+        getControls(),
+        getResponseTimeout());
   }
 
 

--- a/core/src/main/java/org/ldaptive/transport/DefaultCompareOperationHandle.java
+++ b/core/src/main/java/org/ldaptive/transport/DefaultCompareOperationHandle.java
@@ -146,6 +146,12 @@ public class DefaultCompareOperationHandle
    */
   public void compare(final CompareResponse response)
   {
+    if (getMessageID() != response.getMessageID()) {
+      final IllegalArgumentException e = new IllegalArgumentException(
+        "Invalid compare response " + response + " for handle " + this);
+      exception(new LdapException(e));
+      throw e;
+    }
     if (onCompare != null) {
       for (CompareValueHandler func : onCompare) {
         try {

--- a/core/src/main/java/org/ldaptive/transport/DefaultExtendedOperationHandle.java
+++ b/core/src/main/java/org/ldaptive/transport/DefaultExtendedOperationHandle.java
@@ -148,6 +148,12 @@ public class DefaultExtendedOperationHandle
    */
   public void extended(final ExtendedResponse response)
   {
+    if (getMessageID() != response.getMessageID()) {
+      final IllegalArgumentException e = new IllegalArgumentException(
+        "Invalid extended response " + response + " for handle " + this);
+      exception(new LdapException(e));
+      throw e;
+    }
     if (onExtended != null) {
       for (ExtendedValueHandler func : onExtended) {
         try {

--- a/core/src/main/java/org/ldaptive/transport/DefaultOperationHandle.java
+++ b/core/src/main/java/org/ldaptive/transport/DefaultOperationHandle.java
@@ -665,21 +665,17 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
       }
     }
     exception = e;
-    responseSemaphore.release();
+    consumedMessage();
     complete();
   }
 
 
   /**
    * Indicates that a protocol message was consumed by a supplied consumer.
-   *
-   * @deprecated  Use {@link #consumedMessage(Message)}
    */
-  @Deprecated
   protected void consumedMessage()
   {
-    consumedMessage = true;
-    responseSemaphore.release();
+    consumedMessage(true);
   }
 
 
@@ -690,8 +686,19 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
    */
   protected void consumedMessage(final Message message)
   {
+    consumedMessage(getResponseTimeoutCondition().test(message));
+  }
+
+
+  /**
+   * Indicates that a protocol message was consumed by a supplied consumer.
+   *
+   * @param  signalResponseSemaphore  whether to signal the response semaphore
+   */
+  private void consumedMessage(final boolean signalResponseSemaphore)
+  {
     consumedMessage = true;
-    if (getResponseTimeoutCondition().test(message)) {
+    if (signalResponseSemaphore) {
       responseSemaphore.release();
     }
   }

--- a/core/src/main/java/org/ldaptive/transport/DefaultOperationHandle.java
+++ b/core/src/main/java/org/ldaptive/transport/DefaultOperationHandle.java
@@ -3,20 +3,37 @@ package org.ldaptive.transport;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import org.ldaptive.AbandonRequest;
+import org.ldaptive.AddRequest;
+import org.ldaptive.AddResponse;
 import org.ldaptive.BindRequest;
+import org.ldaptive.BindResponse;
+import org.ldaptive.CompareRequest;
+import org.ldaptive.CompareResponse;
+import org.ldaptive.DeleteRequest;
+import org.ldaptive.DeleteResponse;
 import org.ldaptive.LdapException;
+import org.ldaptive.Message;
+import org.ldaptive.ModifyDnRequest;
+import org.ldaptive.ModifyDnResponse;
+import org.ldaptive.ModifyRequest;
+import org.ldaptive.ModifyResponse;
 import org.ldaptive.OperationHandle;
 import org.ldaptive.Request;
 import org.ldaptive.Result;
 import org.ldaptive.ResultCode;
+import org.ldaptive.SearchRequest;
+import org.ldaptive.SearchResponse;
 import org.ldaptive.UnbindRequest;
 import org.ldaptive.control.ResponseControl;
 import org.ldaptive.extended.CancelRequest;
 import org.ldaptive.extended.ExtendedOperationHandle;
+import org.ldaptive.extended.ExtendedRequest;
+import org.ldaptive.extended.ExtendedResponse;
 import org.ldaptive.extended.IntermediateResponse;
 import org.ldaptive.extended.StartTLSRequest;
 import org.ldaptive.extended.UnsolicitedNotification;
@@ -41,6 +58,22 @@ import org.slf4j.LoggerFactory;
  */
 public class DefaultOperationHandle<Q extends Request, S extends Result> implements OperationHandle<Q, S>
 {
+
+  /** Predicate that requires any result message except unsolicited. */
+  private static final Predicate<Message> DEFAULT_RESPONSE_TIMEOUT_CONDITION =
+    new Predicate<>() {
+      @Override
+      public boolean test(final Message message)
+      {
+        return message instanceof Result && !(message instanceof UnsolicitedNotification);
+      }
+
+      @Override
+      public String toString()
+      {
+        return "DEFAULT_RESPONSE_TIMEOUT_CONDITION";
+      }
+    };
 
   /** Logger for this class. */
   protected final Logger logger = LoggerFactory.getLogger(getClass());
@@ -81,8 +114,8 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
   /** Function to run when a result is received to determine whether an exception should be raised. */
   private ResultPredicate throwCondition;
 
-  /** Latch to determine when a response has been received. */
-  private final CountDownLatch responseDone = new CountDownLatch(1);
+  /** Semaphore to determine when a response has been received. */
+  private final Semaphore responseSemaphore = new Semaphore(0);
 
   /** Timestamp when the handle was created. */
   private final Instant creationTime = Instant.now();
@@ -124,6 +157,17 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
   }
 
 
+  /**
+   * Returns a predicate to determine whether the responseTimeout semaphore should be released.
+   *
+   * @return  response timeout condition
+   */
+  protected Predicate<Message> getResponseTimeoutCondition()
+  {
+    return DEFAULT_RESPONSE_TIMEOUT_CONDITION;
+  }
+
+
   @Override
   public DefaultOperationHandle<Q, S> send()
   {
@@ -144,32 +188,35 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
   {
     try {
       if (Duration.ZERO.equals(responseTimeout)) {
-        responseDone.await();
-        if (result != null && exception == null) {
-          logger.trace("await received result {} for handle {}", result, this);
-          if (throwCondition != null) {
-            throwCondition.testAndThrow(result);
-          }
-          return result;
-        }
+        do {
+          logger.trace("await waiting to acquire {} for handle {}", responseSemaphore, this);
+          responseSemaphore.acquire();
+          logger.trace("await acquired {} for handle {}", responseSemaphore, this);
+        } while (result == null && exception == null);
       } else {
-        if (!responseDone.await(responseTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
-          abandon(
-            new LdapException(
-              ResultCode.LDAP_TIMEOUT,
-              "No response received in " + responseTimeout.toMillis() + "ms for handle " + this));
-          logger.trace("await abandoned handle {}", this);
-        } else if (result != null && exception == null) {
-          logger.trace("await received result {} for handle {}", result, this);
-          if (throwCondition != null) {
-            throwCondition.testAndThrow(result);
+        do {
+          logger.trace("await waiting to acquire {} for handle {}", responseSemaphore, this);
+          if (!responseSemaphore.tryAcquire(responseTimeout.toMillis(), TimeUnit.MILLISECONDS)) {
+            abandon(
+              new LdapException(
+                ResultCode.LDAP_TIMEOUT,
+                "No response received in " + responseTimeout.toMillis() + "ms for handle " + this));
+            logger.trace("await failed to acquire {} and abandoned handle {}", responseSemaphore, this);
+            break;
           }
-          return result;
-        }
+          logger.trace("await acquired {} for handle {}", responseSemaphore, this);
+        } while (result == null && exception == null);
       }
     } catch (InterruptedException e) {
-      logger.trace("await interrupted for handle {} waiting for response", this, e);
+      logger.trace("await interrupted acquiring {} for handle {} waiting for response", responseSemaphore, this, e);
       exception(new LdapException(ResultCode.LOCAL_ERROR, e));
+    }
+    if (result != null && exception == null) {
+      logger.trace("await received result {} for handle {}", result, this);
+      if (throwCondition != null) {
+        throwCondition.testAndThrow(result);
+      }
+      return result;
     }
     if (exception == null) {
       throw new LdapException(
@@ -297,6 +344,8 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
       if (receivedTime == null) {
         try {
           connection.operation(new AbandonRequest(messageID));
+        } catch (Exception e) {
+          logger.warn("Could not abandon operation for {}", this, e);
         } finally {
           exception(cause);
         }
@@ -328,6 +377,40 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
       handle.onComplete(completeHandler);
     }
     return handle;
+  }
+
+
+  /**
+   * Whether the supplied result belongs to this handle.
+   *
+   * @param  r  to inspect
+   *
+   * @return  whether the supplied result belong to this handle
+   */
+  private boolean supports(final Result r)
+  {
+    if (messageID != r.getMessageID()) {
+      return false;
+    }
+    boolean supports = false;
+    if (request instanceof AddRequest && r instanceof AddResponse) {
+      supports = true;
+    } else if (request instanceof BindRequest && r instanceof BindResponse) {
+      supports = true;
+    } else if (request instanceof CompareRequest && r instanceof CompareResponse) {
+      supports = true;
+    } else if (request instanceof DeleteRequest && r instanceof DeleteResponse) {
+      supports = true;
+    } else if (request instanceof ExtendedRequest && r instanceof ExtendedResponse) {
+      supports = true;
+    } else if (request instanceof ModifyDnRequest && r instanceof ModifyDnResponse) {
+      supports = true;
+    } else if (request instanceof ModifyRequest && r instanceof ModifyResponse) {
+      supports = true;
+    } else if (request instanceof SearchRequest && r instanceof SearchResponse) {
+      supports = true;
+    }
+    return supports;
   }
 
 
@@ -454,7 +537,14 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
   public void result(final S r)
   {
     if (r == null) {
-      throw new IllegalArgumentException("Result cannot be null for handle " + this);
+      final IllegalArgumentException e = new IllegalArgumentException("Result cannot be null for handle " + this);
+      exception(new LdapException(e));
+      throw e;
+    }
+    if (!supports(r)) {
+      final IllegalArgumentException e = new IllegalArgumentException("Invalid result " + r + " for handle " + this);
+      exception(new LdapException(e));
+      throw e;
     }
     if (onResult != null) {
       for (ResultHandler func : onResult) {
@@ -464,9 +554,9 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
           logger.warn("Result function {} in handle {} threw an exception", func, this, ex);
         }
       }
-      consumedMessage();
     }
     result = r;
+    consumedMessage(r);
     complete();
   }
 
@@ -516,6 +606,12 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
    */
   public void intermediate(final IntermediateResponse r)
   {
+    if (getMessageID() != r.getMessageID()) {
+      final IllegalArgumentException e = new IllegalArgumentException(
+        "Invalid intermediate response " + r + " for handle " + this);
+      exception(new LdapException(e));
+      throw e;
+    }
     if (onIntermediate != null) {
       for (Consumer<IntermediateResponse> func : onIntermediate) {
         try {
@@ -524,8 +620,8 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
           logger.warn("Intermediate response consumer {} in handle {} threw an exception", func, this, ex);
         }
       }
-      consumedMessage();
     }
+    consumedMessage(r);
   }
 
 
@@ -544,8 +640,8 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
           logger.warn("Unsolicited notification consumer {} in handle {} threw an exception", func, this, ex);
         }
       }
-      consumedMessage();
     }
+    consumedMessage(u);
   }
 
 
@@ -557,7 +653,9 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
   public void exception(final LdapException e)
   {
     if (e == null) {
-      throw new IllegalArgumentException("Exception cannot be null for handle " + this);
+      final IllegalArgumentException ex = new IllegalArgumentException("Exception cannot be null for handle " + this);
+      exception(new LdapException(ex));
+      throw ex;
     }
     if (onException != null) {
       try {
@@ -567,16 +665,35 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
       }
     }
     exception = e;
+    responseSemaphore.release();
     complete();
   }
 
 
   /**
    * Indicates that a protocol message was consumed by a supplied consumer.
+   *
+   * @deprecated  Use {@link #consumedMessage(Message)}
    */
+  @Deprecated
   protected void consumedMessage()
   {
     consumedMessage = true;
+    responseSemaphore.release();
+  }
+
+
+  /**
+   * Indicates that a protocol message was consumed by a supplied consumer.
+   *
+   * @param  message  that was consumed
+   */
+  protected void consumedMessage(final Message message)
+  {
+    consumedMessage = true;
+    if (getResponseTimeoutCondition().test(message)) {
+      responseSemaphore.release();
+    }
   }
 
 
@@ -584,23 +701,19 @@ public class DefaultOperationHandle<Q extends Request, S extends Result> impleme
    * Releases the latch and sets the response as received. Invokes {@link #onComplete}. Handle is considered done when
    * this is invoked.
    */
-  private void complete()
+  private synchronized void complete()
   {
     try {
       if (receivedTime != null) {
-        logger.warn("Operation already complete for handle {}", this);
+        logger.debug("Operation already complete for handle {}", this);
         return;
       }
-      try {
-        responseDone.countDown();
-      } finally {
-        receivedTime = Instant.now();
-        if (onComplete != null) {
-          try {
-            onComplete.execute();
-          } catch (Exception e) {
-            logger.warn("Complete consumer {} in handle {} threw an exception", onComplete, this, e);
-          }
+      receivedTime = Instant.now();
+      if (onComplete != null) {
+        try {
+          onComplete.execute();
+        } catch (Exception e) {
+          logger.warn("Complete consumer {} in handle {} threw an exception", onComplete, this, e);
         }
       }
     } finally {

--- a/core/src/main/java/org/ldaptive/transport/DefaultSearchOperationHandle.java
+++ b/core/src/main/java/org/ldaptive/transport/DefaultSearchOperationHandle.java
@@ -3,12 +3,15 @@ package org.ldaptive.transport;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.function.Predicate;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
+import org.ldaptive.Message;
 import org.ldaptive.SearchOperationHandle;
 import org.ldaptive.SearchRequest;
 import org.ldaptive.SearchResponse;
 import org.ldaptive.SearchResultReference;
+import org.ldaptive.extended.IntermediateResponse;
 import org.ldaptive.handler.CompleteHandler;
 import org.ldaptive.handler.ExceptionHandler;
 import org.ldaptive.handler.IntermediateResponseHandler;
@@ -29,6 +32,25 @@ import org.ldaptive.handler.UnsolicitedNotificationHandler;
 public class DefaultSearchOperationHandle
   extends DefaultOperationHandle<SearchRequest, SearchResponse> implements SearchOperationHandle
 {
+
+  /** Predicate that requires any message except unsolicited. */
+  private static final Predicate<Message> SEARCH_RESPONSE_TIMEOUT_CONDITION =
+    new Predicate<>() {
+      @Override
+      public boolean test(final Message message)
+      {
+        return message instanceof IntermediateResponse ||
+          message instanceof LdapEntry ||
+          message instanceof SearchResultReference ||
+          message instanceof SearchResponse;
+      }
+
+      @Override
+      public String toString()
+      {
+        return "SEARCH_RESPONSE_TIMEOUT_CONDITION";
+      }
+    };
 
   /** Whether to automatically sort search results. */
   private static final boolean SORT_RESULTS = Boolean.parseBoolean(
@@ -57,6 +79,13 @@ public class DefaultSearchOperationHandle
   public DefaultSearchOperationHandle(final SearchRequest req, final TransportConnection conn, final Duration timeout)
   {
     super(req, conn, timeout);
+  }
+
+
+  @Override
+  protected Predicate<Message> getResponseTimeoutCondition()
+  {
+    return SEARCH_RESPONSE_TIMEOUT_CONDITION;
   }
 
 
@@ -214,6 +243,11 @@ public class DefaultSearchOperationHandle
    */
   public void entry(final LdapEntry r)
   {
+    if (getMessageID() != r.getMessageID()) {
+      final IllegalArgumentException e = new IllegalArgumentException("Invalid entry " + r + " for handle " + this);
+      exception(new LdapException(e));
+      throw e;
+    }
     LdapEntry e = r;
     if (onEntry != null) {
       for (LdapEntryHandler func : onEntry) {
@@ -223,11 +257,11 @@ public class DefaultSearchOperationHandle
           logger.warn("Entry function {} in handle {} threw an exception", func, this, ex);
         }
       }
-      consumedMessage();
     }
     if (e != null) {
       result.addEntries(e);
     }
+    consumedMessage(r);
   }
 
 
@@ -238,6 +272,11 @@ public class DefaultSearchOperationHandle
    */
   public void reference(final SearchResultReference r)
   {
+    if (getMessageID() != r.getMessageID()) {
+      final IllegalArgumentException e = new IllegalArgumentException("Invalid reference " + r + " for handle " + this);
+      exception(new LdapException(e));
+      throw e;
+    }
     if (onReference != null) {
       for (SearchReferenceHandler func : onReference) {
         try {
@@ -246,9 +285,9 @@ public class DefaultSearchOperationHandle
           logger.warn("Reference consumer {} in handle {} threw an exception", func, this, ex);
         }
       }
-      consumedMessage();
     }
     result.addReferences(r);
+    consumedMessage(r);
   }
 
 

--- a/core/src/main/java/org/ldaptive/transport/netty/NettyConnection.java
+++ b/core/src/main/java/org/ldaptive/transport/netty/NettyConnection.java
@@ -48,6 +48,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ScheduledFuture;
 import org.ldaptive.AbandonRequest;
+import org.ldaptive.AbstractRequestMessage;
 import org.ldaptive.AddRequest;
 import org.ldaptive.AddResponse;
 import org.ldaptive.BindRequest;
@@ -594,7 +595,7 @@ public final class NettyConnection extends TransportConnection
     final DefaultExtendedOperationHandle handle = new DefaultExtendedOperationHandle(
       request,
       this,
-      connectionConfig.getStartTLSTimeout());
+      request.getResponseTimeout() != null ? request.getResponseTimeout() : connectionConfig.getStartTLSTimeout());
     final Result result;
     try {
       result = handle.execute();
@@ -817,13 +818,23 @@ public final class NettyConnection extends TransportConnection
   @Override
   public DefaultOperationHandle<AddRequest, AddResponse> operation(final AddRequest request)
   {
-    return new DefaultOperationHandle<>(request, this, connectionConfig.getResponseTimeout());
+    return new DefaultOperationHandle<>(
+      request,
+      this,
+      request.getResponseTimeout() != null ? request.getResponseTimeout() : connectionConfig.getResponseTimeout());
   }
 
 
   @Override
   public BindOperationHandle operation(final BindRequest request)
   {
+    if (request instanceof AbstractRequestMessage) {
+      return new BindOperationHandle(
+        request,
+        this,
+        ((AbstractRequestMessage) request).getResponseTimeout() != null ?
+          ((AbstractRequestMessage) request).getResponseTimeout() : connectionConfig.getResponseTimeout());
+    }
     return new BindOperationHandle(request, this, connectionConfig.getResponseTimeout());
   }
 
@@ -831,14 +842,20 @@ public final class NettyConnection extends TransportConnection
   @Override
   public DefaultCompareOperationHandle operation(final CompareRequest request)
   {
-    return new DefaultCompareOperationHandle(request, this, connectionConfig.getResponseTimeout());
+    return new DefaultCompareOperationHandle(
+      request,
+      this,
+      request.getResponseTimeout() != null ? request.getResponseTimeout() : connectionConfig.getResponseTimeout());
   }
 
 
   @Override
   public DefaultOperationHandle<DeleteRequest, DeleteResponse> operation(final DeleteRequest request)
   {
-    return new DefaultOperationHandle<>(request, this, connectionConfig.getResponseTimeout());
+    return new DefaultOperationHandle<>(
+      request,
+      this,
+      request.getResponseTimeout() != null ? request.getResponseTimeout() : connectionConfig.getResponseTimeout());
   }
 
 
@@ -848,28 +865,40 @@ public final class NettyConnection extends TransportConnection
     if (request instanceof StartTLSRequest) {
       throw new IllegalArgumentException("StartTLS can only be invoked when the connection is opened");
     }
-    return new DefaultExtendedOperationHandle(request, this, connectionConfig.getResponseTimeout());
+    return new DefaultExtendedOperationHandle(
+      request,
+      this,
+      request.getResponseTimeout() != null ? request.getResponseTimeout() : connectionConfig.getResponseTimeout());
   }
 
 
   @Override
   public DefaultOperationHandle<ModifyRequest, ModifyResponse> operation(final ModifyRequest request)
   {
-    return new DefaultOperationHandle<>(request, this, connectionConfig.getResponseTimeout());
+    return new DefaultOperationHandle<>(
+      request,
+      this,
+      request.getResponseTimeout() != null ? request.getResponseTimeout() : connectionConfig.getResponseTimeout());
   }
 
 
   @Override
   public DefaultOperationHandle<ModifyDnRequest, ModifyDnResponse> operation(final ModifyDnRequest request)
   {
-    return new DefaultOperationHandle<>(request, this, connectionConfig.getResponseTimeout());
+    return new DefaultOperationHandle<>(
+      request,
+      this,
+      request.getResponseTimeout() != null ? request.getResponseTimeout() : connectionConfig.getResponseTimeout());
   }
 
 
   @Override
   public DefaultSearchOperationHandle operation(final SearchRequest request)
   {
-    return new DefaultSearchOperationHandle(request, this, connectionConfig.getResponseTimeout());
+    return new DefaultSearchOperationHandle(
+      request,
+      this,
+      request.getResponseTimeout() != null ? request.getResponseTimeout() : connectionConfig.getResponseTimeout());
   }
 
 

--- a/core/src/test/java/org/ldaptive/CompareRequestTest.java
+++ b/core/src/test/java/org/ldaptive/CompareRequestTest.java
@@ -68,31 +68,31 @@ public class CompareRequestTest
     // CheckStyle:Indentation OFF
     Assert.assertEquals(
       CompareRequest.builder().build().toString().split("::")[1],
-      "controls=null, dn=null, attributeDesc=null, assertionValue=null");
+      "controls=null, responseTimeout=null, dn=null, attributeDesc=null, assertionValue=null");
     Assert.assertEquals(
       new CompareRequest(null, null, null).toString().split("::")[1],
-      "controls=null, dn=null, attributeDesc=null, assertionValue=null");
+      "controls=null, responseTimeout=null, dn=null, attributeDesc=null, assertionValue=null");
     Assert.assertEquals(
       new CompareRequest("uid=1", null, null).toString().split("::")[1],
-      "controls=null, dn=uid=1, attributeDesc=null, assertionValue=null");
+      "controls=null, responseTimeout=null, dn=uid=1, attributeDesc=null, assertionValue=null");
     Assert.assertEquals(
       new CompareRequest(null, "name", null).toString().split("::")[1],
-      "controls=null, dn=null, attributeDesc=name, assertionValue=null");
+      "controls=null, responseTimeout=null, dn=null, attributeDesc=name, assertionValue=null");
     Assert.assertEquals(
       new CompareRequest(null, null, "value").toString().split("::")[1],
-      "controls=null, dn=null, attributeDesc=null, assertionValue=value");
+      "controls=null, responseTimeout=null, dn=null, attributeDesc=null, assertionValue=value");
     Assert.assertEquals(
       new CompareRequest(null, "name", "value").toString().split("::")[1],
-      "controls=null, dn=null, attributeDesc=name, assertionValue=value");
+      "controls=null, responseTimeout=null, dn=null, attributeDesc=name, assertionValue=value");
     Assert.assertEquals(
       new CompareRequest(null, "userPassword", "password").toString().split("::")[1],
-      "controls=null, dn=null, attributeDesc=userPassword, assertionValue=<suppressed>");
+      "controls=null, responseTimeout=null, dn=null, attributeDesc=userPassword, assertionValue=<suppressed>");
     Assert.assertEquals(
       new CompareRequest("uid=1", "userPassword", "password").toString().split("::")[1],
-      "controls=null, dn=uid=1, attributeDesc=userPassword, assertionValue=<suppressed>");
+      "controls=null, responseTimeout=null, dn=uid=1, attributeDesc=userPassword, assertionValue=<suppressed>");
     Assert.assertEquals(
       new CompareRequest("uid=1", "name", "value").toString().split("::")[1],
-      "controls=null, dn=uid=1, attributeDesc=name, assertionValue=value");
+      "controls=null, responseTimeout=null, dn=uid=1, attributeDesc=name, assertionValue=value");
     // CheckStyle:Indentation ON
   }
 }

--- a/core/src/test/java/org/ldaptive/ad/handler/RangeEntryHandlerTest.java
+++ b/core/src/test/java/org/ldaptive/ad/handler/RangeEntryHandlerTest.java
@@ -39,6 +39,7 @@ public class RangeEntryHandlerTest
       new Object[][] {
         new Object[] {
           LdapEntry.builder()
+            .messageID(1)
             .dn("cn=test-group,ou=groups,dc=ldaptive,dc=org")
             .attributes(LdapAttribute.builder()
               .name("member;Range=0-4")
@@ -46,6 +47,7 @@ public class RangeEntryHandlerTest
               .build())
             .build(),
           LdapEntry.builder()
+            .messageID(1)
             .dn("cn=test-group,ou=groups,dc=ldaptive,dc=org")
             .attributes(LdapAttribute.builder()
               .name("member;Range=5-*")
@@ -68,16 +70,20 @@ public class RangeEntryHandlerTest
       h.messageID(1);
       h.sent();
       ((DefaultSearchOperationHandle) h).entry(entry2);
-      ((DefaultSearchOperationHandle) h).result(SearchResponse.builder().resultCode(ResultCode.SUCCESS).build());
+      ((DefaultSearchOperationHandle) h).result(
+        SearchResponse.builder().messageID(1).resultCode(ResultCode.SUCCESS).build());
     });
     handler.setConnection(conn);
-    final SearchResponse response = SearchResponse.builder().resultCode(ResultCode.SUCCESS).entry(entry1).build();
+    final SearchResponse response =
+      SearchResponse.builder().messageID(1).resultCode(ResultCode.SUCCESS).entry(entry1).build();
     final SearchResponse rangeResponse = handler.apply(response);
     Assert.assertNotNull(rangeResponse);
     Assert.assertEquals(
       SearchResponse.builder()
+        .messageID(1)
         .resultCode(ResultCode.SUCCESS)
         .entry(LdapEntry.builder()
+          .messageID(1)
           .dn("cn=test-group,ou=groups,dc=ldaptive,dc=org")
           .attributes(LdapAttribute.builder()
             .name("member")

--- a/core/src/test/java/org/ldaptive/transport/DefaultOperationHandleTest.java
+++ b/core/src/test/java/org/ldaptive/transport/DefaultOperationHandleTest.java
@@ -1,0 +1,314 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.transport;
+
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.ldaptive.AddRequest;
+import org.ldaptive.AddResponse;
+import org.ldaptive.AnonymousBindRequest;
+import org.ldaptive.BindRequest;
+import org.ldaptive.BindResponse;
+import org.ldaptive.ConnectionConfig;
+import org.ldaptive.DeleteRequest;
+import org.ldaptive.DeleteResponse;
+import org.ldaptive.LdapException;
+import org.ldaptive.Request;
+import org.ldaptive.Result;
+import org.ldaptive.ResultCode;
+import org.ldaptive.extended.IntermediateResponse;
+import org.ldaptive.transport.mock.MockConnection;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@link DefaultOperationHandle}.
+ *
+ * @author  Middleware Services
+ */
+public class DefaultOperationHandleTest
+{
+
+  /** To schedule test results. */
+  private ScheduledExecutorService executorService;
+
+
+  /**
+   * Returns test data.
+   *
+   * @return  operation handles
+   */
+  @DataProvider(name = "default-handles")
+  public Object[][] createHandles()
+  {
+    return
+      new Object[][] {
+        new Object[] {
+          new DefaultOperationHandle<AddRequest, AddResponse>(
+            AddRequest.builder().build(),
+            MockConnection.builder(
+              ConnectionConfig.builder().url("ldap://ds1.ldaptive.org").build()).abandonConsumer(req -> {}).build(),
+            Duration.ZERO),
+          AddResponse.builder().messageID(1).build(),
+          Duration.ofSeconds(2),
+          false,
+        },
+        new Object[] {
+          new DefaultOperationHandle<BindRequest, BindResponse>(
+            AnonymousBindRequest.builder().build(),
+            MockConnection.builder(
+              ConnectionConfig.builder().url("ldap://ds1.ldaptive.org").build()).abandonConsumer(req -> {}).build(),
+            Duration.ofSeconds(1)),
+          BindResponse.builder().messageID(1).build(),
+          Duration.ofSeconds(2),
+          true,
+        },
+        new Object[] {
+          new DefaultOperationHandle<DeleteRequest, DeleteResponse>(
+            DeleteRequest.builder().build(),
+            MockConnection.builder(
+              ConnectionConfig.builder().url("ldap://ds1.ldaptive.org").build()).abandonConsumer(req -> {}).build(),
+            Duration.ofSeconds(3)),
+          DeleteResponse.builder().messageID(1).build(),
+          Duration.ofSeconds(2),
+          false,
+        },
+      };
+  }
+
+
+  @BeforeClass
+  public void setup()
+  {
+    executorService = Executors.newScheduledThreadPool(5);
+  }
+
+
+  @AfterClass
+  public void shutdown()
+  {
+    executorService.shutdown();
+  }
+
+
+  /**
+   * @param  handle  to test
+   * @param  response  to send to handle
+   * @param  responseTime  time to wait until sending the response
+   * @param  throwsTimeout  whether a timeout exception is expected
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport", dataProvider = "default-handles")
+  public void awaitResult(
+    final DefaultOperationHandle<Request, Result> handle,
+    final Result response,
+    final Duration responseTime,
+    final boolean throwsTimeout)
+    throws Exception
+  {
+    executorService.schedule(() -> handle.result(response), responseTime.toMillis(), TimeUnit.MILLISECONDS);
+    if (throwsTimeout) {
+      try {
+        handle.execute();
+        Assert.fail("Should have thrown exception");
+      } catch (Exception ex) {
+        if (ex instanceof LdapException) {
+          Assert.assertEquals(ResultCode.LDAP_TIMEOUT, ((LdapException) ex).getResultCode());
+        } else {
+          throw ex;
+        }
+      }
+    } else {
+      Assert.assertEquals(handle.execute(), response);
+    }
+  }
+
+
+  /**
+   * @param  handle  to test
+   * @param  response  to send to handle
+   * @param  responseTime  time to wait until sending the response
+   * @param  throwsTimeout  whether a timeout exception is expected
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport", dataProvider = "default-handles")
+  public void awaitResultWithIntermediate(
+    final DefaultOperationHandle<Request, Result> handle,
+    final Result response,
+    final Duration responseTime,
+    final boolean throwsTimeout)
+    throws Exception
+  {
+    // timeout will occur since messages do not restart the wait time
+    executorService.schedule(
+      () -> handle.intermediate(
+        IntermediateResponse.builder().messageID(1).build()),
+      responseTime.dividedBy(4).toMillis(),
+      TimeUnit.MILLISECONDS);
+    executorService.schedule(
+      () -> handle.intermediate(
+        IntermediateResponse.builder().messageID(1).build()),
+      responseTime.dividedBy(2).toMillis(),
+      TimeUnit.MILLISECONDS);
+    executorService.schedule(
+      () -> handle.intermediate(
+        IntermediateResponse.builder().messageID(1).build()),
+      responseTime.multipliedBy(3).dividedBy(4).toMillis(),
+      TimeUnit.MILLISECONDS);
+    executorService.schedule(() -> handle.result(response), responseTime.toMillis(), TimeUnit.MILLISECONDS);
+    if (throwsTimeout) {
+      try {
+        handle.execute();
+        Assert.fail("Should have thrown exception");
+      } catch (Exception ex) {
+        if (ex instanceof LdapException) {
+          Assert.assertEquals(ResultCode.LDAP_TIMEOUT, ((LdapException) ex).getResultCode());
+        } else {
+          throw ex;
+        }
+      }
+    } else {
+      Assert.assertEquals(handle.execute(), response);
+    }
+  }
+
+
+  /**
+   * @param  handle  to test
+   * @param  response  to send to handle
+   * @param  responseTime  time to wait until sending the response
+   * @param  throwsTimeout  whether a timeout exception is expected
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport", dataProvider = "default-handles")
+  public void awaitResultWithIntermediateThrows(
+    final DefaultOperationHandle<Request, Result> handle,
+    final Result response,
+    final Duration responseTime,
+    final boolean throwsTimeout)
+    throws Exception
+  {
+    executorService.schedule(
+      () -> handle.intermediate(
+        IntermediateResponse.builder().messageID(1).build()),
+      responseTime.dividedBy(4).toMillis(),
+      TimeUnit.MILLISECONDS);
+    executorService.schedule(
+      () -> handle.intermediate(
+        IntermediateResponse.builder().messageID(1).build()),
+      responseTime.dividedBy(2).toMillis(),
+      TimeUnit.MILLISECONDS);
+    executorService.schedule(
+      () -> handle.intermediate(
+        IntermediateResponse.builder().messageID(1).build()),
+      responseTime.multipliedBy(3).dividedBy(4).toMillis(),
+      TimeUnit.MILLISECONDS);
+    if (throwsTimeout) {
+      executorService.schedule(
+        () -> handle.result(response), responseTime.multipliedBy(2).toMillis(), TimeUnit.MILLISECONDS);
+      try {
+        handle.execute();
+        Assert.fail("Should have thrown exception");
+      } catch (Exception ex) {
+        if (ex instanceof LdapException) {
+          Assert.assertEquals(ResultCode.LDAP_TIMEOUT, ((LdapException) ex).getResultCode());
+        } else {
+          throw ex;
+        }
+      }
+    } else {
+      executorService.schedule(() -> handle.result(response), responseTime.toMillis(), TimeUnit.MILLISECONDS);
+      Assert.assertEquals(handle.execute(), response);
+    }
+  }
+
+
+  /**
+   * @param  handle  to test
+   * @param  response  to send to handle
+   * @param  responseTime  time to wait until sending the response
+   * @param  throwsTimeout  whether a timeout exception is expected
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport", dataProvider = "default-handles")
+  public void awaitException(
+    final DefaultOperationHandle<Request, Result> handle,
+    final Result response,
+    final Duration responseTime,
+    final boolean throwsTimeout)
+    throws Exception
+  {
+    final LdapException e = new LdapException("Test exception");
+    executorService.schedule(() -> handle.exception(e), responseTime.toMillis(), TimeUnit.MILLISECONDS);
+    try {
+      handle.execute();
+      Assert.fail("Should have thrown exception");
+    } catch (Exception ex) {
+      if (throwsTimeout) {
+        if (ex instanceof LdapException) {
+          Assert.assertEquals(ResultCode.LDAP_TIMEOUT, ((LdapException) ex).getResultCode());
+        } else {
+          throw ex;
+        }
+      } else {
+        Assert.assertEquals(ex, e);
+      }
+    }
+  }
+
+
+  /**
+   * @param  handle  to test
+   * @param  response  to send to handle
+   * @param  responseTime  time to wait until sending the response
+   * @param  throwsTimeout  whether a timeout exception is expected
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport", dataProvider = "default-handles")
+  public void awaitInterrupted(
+    final DefaultOperationHandle<Request, Result> handle,
+    final Result response,
+    final Duration responseTime,
+    final boolean throwsTimeout)
+    throws Throwable
+  {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<LdapException> ldapException = new AtomicReference<>();
+    handle.onException(e -> {
+      ldapException.set(e);
+      latch.countDown();
+    });
+    final Future<?> future = executorService.submit(() -> {
+      try {
+        handle.execute();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    try {
+      // allow some time for the handle to start blocking
+      Thread.sleep(100);
+      future.cancel(true);
+      future.get();
+    } catch (Exception e) {
+      Assert.assertEquals(CancellationException.class, e.getClass());
+    }
+    if (!latch.await(Duration.ofSeconds(2).toMillis(), TimeUnit.MILLISECONDS)) {
+      Assert.fail("Exception was not set on the handle");
+    }
+    Assert.assertEquals(ResultCode.LOCAL_ERROR, ldapException.get().getResultCode());
+  }
+}

--- a/core/src/test/java/org/ldaptive/transport/DefaultSearchOperationHandleTest.java
+++ b/core/src/test/java/org/ldaptive/transport/DefaultSearchOperationHandleTest.java
@@ -1,0 +1,372 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.transport;
+
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.ldaptive.ConnectionConfig;
+import org.ldaptive.LdapEntry;
+import org.ldaptive.LdapException;
+import org.ldaptive.ResultCode;
+import org.ldaptive.SearchRequest;
+import org.ldaptive.SearchResponse;
+import org.ldaptive.SearchResultReference;
+import org.ldaptive.extended.IntermediateResponse;
+import org.ldaptive.transport.mock.MockConnection;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@link DefaultSearchOperationHandle}.
+ *
+ * @author  Middleware Services
+ */
+public class DefaultSearchOperationHandleTest
+{
+
+  /** To schedule test results. */
+  private ScheduledExecutorService executorService;
+
+
+  /**
+   * Returns test data.
+   *
+   * @return  operation handles
+   */
+  @DataProvider(name = "search-handles")
+  public Object[][] createHandles()
+  {
+    return
+      new Object[][] {
+        new Object[] {
+          new DefaultSearchOperationHandle(
+            SearchRequest.builder().build(),
+            MockConnection.builder(
+              ConnectionConfig.builder().url("ldap://ds1.ldaptive.org").build()).abandonConsumer(req -> {}).build(),
+            Duration.ZERO),
+          SearchResponse.builder().messageID(1).build(),
+          Duration.ofSeconds(2),
+          false,
+        },
+        new Object[] {
+          new DefaultSearchOperationHandle(
+            SearchRequest.builder().build(),
+            MockConnection.builder(
+              ConnectionConfig.builder().url("ldap://ds1.ldaptive.org").build()).abandonConsumer(req -> {}).build(),
+            Duration.ofSeconds(1)),
+          SearchResponse.builder().messageID(1).build(),
+          Duration.ofSeconds(2),
+          true,
+        },
+        new Object[] {
+          new DefaultSearchOperationHandle(
+            SearchRequest.builder().build(),
+            MockConnection.builder(
+              ConnectionConfig.builder().url("ldap://ds1.ldaptive.org").build()).abandonConsumer(req -> {}).build(),
+            Duration.ofSeconds(3)),
+          SearchResponse.builder().messageID(1).build(),
+          Duration.ofSeconds(2),
+          false,
+        },
+      };
+  }
+
+
+  @BeforeClass
+  public void setup()
+  {
+    executorService = Executors.newScheduledThreadPool(5);
+  }
+
+
+  @AfterClass
+  public void shutdown()
+  {
+    executorService.shutdown();
+  }
+
+
+  /**
+   * @param  handle  to test
+   * @param  response  to send to handle
+   * @param  responseTime  time to wait until sending the response
+   * @param  throwsTimeout  whether a timeout exception is expected
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport", dataProvider = "search-handles")
+  public void awaitResult(
+    final DefaultSearchOperationHandle handle,
+    final SearchResponse response,
+    final Duration responseTime,
+    final boolean throwsTimeout)
+    throws Exception
+  {
+    executorService.schedule(() -> handle.result(response), responseTime.toMillis(), TimeUnit.MILLISECONDS);
+    if (throwsTimeout) {
+      try {
+        handle.execute();
+        Assert.fail("Should have thrown exception");
+      } catch (Exception ex) {
+        if (ex instanceof LdapException) {
+          Assert.assertEquals(ResultCode.LDAP_TIMEOUT, ((LdapException) ex).getResultCode());
+        } else {
+          throw ex;
+        }
+      }
+    } else {
+      Assert.assertEquals(handle.execute(), response);
+    }
+  }
+
+
+  /**
+   * @param  handle  to test
+   * @param  response  to send to handle
+   * @param  responseTime  time to wait until sending the response
+   * @param  throwsTimeout  whether a timeout exception is expected
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport", dataProvider = "search-handles")
+  public void awaitResultWithEntries(
+    final DefaultSearchOperationHandle handle,
+    final SearchResponse response,
+    final Duration responseTime,
+    final boolean throwsTimeout)
+    throws Exception
+  {
+    final LdapEntry entry1 = LdapEntry.builder().messageID(1).dn("uid=1,ou=robots,dc=ldaptive,dc=org").build();
+    final LdapEntry entry2 = LdapEntry.builder().messageID(1).dn("uid=2,ou=robots,dc=ldaptive,dc=org").build();
+    final SearchResultReference ref1 =
+      SearchResultReference.builder().messageID(1).uris("ldap://ds2.ldaptive.org/dc=example,dc=com??sub?").build();
+    // timeout will not occur since messages restart the wait time
+    executorService.schedule(() -> handle.entry(entry1), responseTime.dividedBy(4).toMillis(), TimeUnit.MILLISECONDS);
+    executorService.schedule(() -> handle.reference(ref1), responseTime.dividedBy(2).toMillis(), TimeUnit.MILLISECONDS);
+    executorService.schedule(
+      () -> handle.entry(entry2), responseTime.multipliedBy(3).dividedBy(4).toMillis(), TimeUnit.MILLISECONDS);
+    executorService.schedule(() -> handle.result(response), responseTime.toMillis(), TimeUnit.MILLISECONDS);
+    Assert.assertEquals(
+      handle.execute(), SearchResponse.builder().messageID(1).entry(entry1, entry2).reference(ref1).build());
+  }
+
+
+  /**
+   * @param  handle  to test
+   * @param  response  to send to handle
+   * @param  responseTime  time to wait until sending the response
+   * @param  throwsTimeout  whether a timeout exception is expected
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport", dataProvider = "search-handles")
+  public void awaitResultWithEntriesThrows(
+    final DefaultSearchOperationHandle handle,
+    final SearchResponse response,
+    final Duration responseTime,
+    final boolean throwsTimeout)
+    throws Exception
+  {
+    final LdapEntry entry1 = LdapEntry.builder().messageID(1).dn("uid=1,ou=robots,dc=ldaptive,dc=org").build();
+    final LdapEntry entry2 = LdapEntry.builder().messageID(1).dn("uid=2,ou=robots,dc=ldaptive,dc=org").build();
+    final SearchResultReference ref1 =
+      SearchResultReference.builder().messageID(1).uris("ldap://ds2.ldaptive.org/dc=example,dc=com??sub?").build();
+    executorService.schedule(() -> handle.entry(entry1), responseTime.dividedBy(4).toMillis(), TimeUnit.MILLISECONDS);
+    executorService.schedule(() -> handle.reference(ref1), responseTime.dividedBy(2).toMillis(), TimeUnit.MILLISECONDS);
+    executorService.schedule(
+      () -> handle.entry(entry2), responseTime.multipliedBy(3).dividedBy(4).toMillis(), TimeUnit.MILLISECONDS);
+    if (throwsTimeout) {
+      executorService.schedule(
+        () -> handle.result(response), responseTime.multipliedBy(2).toMillis(), TimeUnit.MILLISECONDS);
+      try {
+        handle.execute();
+        Assert.fail("Should have thrown exception");
+      } catch (Exception ex) {
+        if (ex instanceof LdapException) {
+          Assert.assertEquals(ResultCode.LDAP_TIMEOUT, ((LdapException) ex).getResultCode());
+        } else {
+          throw ex;
+        }
+      }
+    } else {
+      executorService.schedule(() -> handle.result(response), responseTime.toMillis(), TimeUnit.MILLISECONDS);
+      Assert.assertEquals(
+        handle.execute(), SearchResponse.builder().messageID(1).entry(entry1, entry2).reference(ref1).build());
+    }
+  }
+
+
+  /**
+   * @param  handle  to test
+   * @param  response  to send to handle
+   * @param  responseTime  time to wait until sending the response
+   * @param  throwsTimeout  whether a timeout exception is expected
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport", dataProvider = "search-handles")
+  public void awaitResultWithIntermediate(
+    final DefaultSearchOperationHandle handle,
+    final SearchResponse response,
+    final Duration responseTime,
+    final boolean throwsTimeout)
+    throws Exception
+  {
+    // timeout will not occur since messages restart the wait time
+    executorService.schedule(
+      () -> handle.intermediate(
+        IntermediateResponse.builder().messageID(1).build()),
+      responseTime.dividedBy(4).toMillis(),
+      TimeUnit.MILLISECONDS);
+    executorService.schedule(
+      () -> handle.intermediate(
+        IntermediateResponse.builder().messageID(1).build()),
+      responseTime.dividedBy(2).toMillis(),
+      TimeUnit.MILLISECONDS);
+    executorService.schedule(
+      () -> handle.intermediate(
+        IntermediateResponse.builder().messageID(1).build()),
+      responseTime.multipliedBy(3).dividedBy(4).toMillis(),
+      TimeUnit.MILLISECONDS);
+    executorService.schedule(() -> handle.result(response), responseTime.toMillis(), TimeUnit.MILLISECONDS);
+    Assert.assertEquals(handle.execute(), response);
+  }
+
+
+  /**
+   * @param  handle  to test
+   * @param  response  to send to handle
+   * @param  responseTime  time to wait until sending the response
+   * @param  throwsTimeout  whether a timeout exception is expected
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport", dataProvider = "search-handles")
+  public void awaitResultWithIntermediateThrows(
+    final DefaultSearchOperationHandle handle,
+    final SearchResponse response,
+    final Duration responseTime,
+    final boolean throwsTimeout)
+    throws Exception
+  {
+    executorService.schedule(
+      () -> handle.intermediate(
+        IntermediateResponse.builder().messageID(1).build()),
+      responseTime.dividedBy(4).toMillis(),
+      TimeUnit.MILLISECONDS);
+    executorService.schedule(
+      () -> handle.intermediate(
+        IntermediateResponse.builder().messageID(1).build()),
+      responseTime.dividedBy(2).toMillis(),
+      TimeUnit.MILLISECONDS);
+    executorService.schedule(
+      () -> handle.intermediate(
+        IntermediateResponse.builder().messageID(1).build()),
+      responseTime.multipliedBy(3).dividedBy(4).toMillis(),
+      TimeUnit.MILLISECONDS);
+    if (throwsTimeout) {
+      executorService.schedule(
+        () -> handle.result(response), responseTime.multipliedBy(2).toMillis(), TimeUnit.MILLISECONDS);
+      try {
+        handle.execute();
+        Assert.fail("Should have thrown exception");
+      } catch (Exception ex) {
+        if (ex instanceof LdapException) {
+          Assert.assertEquals(ResultCode.LDAP_TIMEOUT, ((LdapException) ex).getResultCode());
+        } else {
+          throw ex;
+        }
+      }
+    } else {
+      executorService.schedule(() -> handle.result(response), responseTime.toMillis(), TimeUnit.MILLISECONDS);
+      Assert.assertEquals(handle.execute(), response);
+    }
+  }
+
+
+  /**
+   * @param  handle  to test
+   * @param  response  to send to handle
+   * @param  responseTime  time to wait until sending the response
+   * @param  throwsTimeout  whether a timeout exception is expected
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport", dataProvider = "search-handles")
+  public void awaitException(
+    final DefaultSearchOperationHandle handle,
+    final SearchResponse response,
+    final Duration responseTime,
+    final boolean throwsTimeout)
+    throws Exception
+  {
+    final LdapException e = new LdapException("Test exception");
+    executorService.schedule(() -> handle.exception(e), responseTime.toMillis(), TimeUnit.MILLISECONDS);
+    try {
+      handle.execute();
+      Assert.fail("Should have thrown exception");
+    } catch (Exception ex) {
+      if (throwsTimeout) {
+        if (ex instanceof LdapException) {
+          Assert.assertEquals(ResultCode.LDAP_TIMEOUT, ((LdapException) ex).getResultCode());
+        } else {
+          throw ex;
+        }
+      } else {
+        Assert.assertEquals(ex, e);
+      }
+    }
+  }
+
+
+  /**
+   * @param  handle  to test
+   * @param  response  to send to handle
+   * @param  responseTime  time to wait until sending the response
+   * @param  throwsTimeout  whether a timeout exception is expected
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport", dataProvider = "search-handles")
+  public void awaitInterrupted(
+    final DefaultSearchOperationHandle handle,
+    final SearchResponse response,
+    final Duration responseTime,
+    final boolean throwsTimeout)
+    throws Throwable
+  {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<LdapException> ldapException = new AtomicReference<>();
+    handle.onException(e -> {
+      ldapException.set(e);
+      latch.countDown();
+    });
+    final Future<?> future = executorService.submit(() -> {
+      try {
+        handle.execute();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+    try {
+      // allow some time for the handle to start blocking
+      Thread.sleep(100);
+      future.cancel(true);
+      future.get();
+    } catch (Exception e) {
+      Assert.assertEquals(CancellationException.class, e.getClass());
+    }
+    if (!latch.await(Duration.ofSeconds(2).toMillis(), TimeUnit.MILLISECONDS)) {
+      Assert.fail("Exception was not set on the handle");
+    }
+    Assert.assertEquals(ResultCode.LOCAL_ERROR, ldapException.get().getResultCode());
+  }
+}


### PR DESCRIPTION
Change from a countDownLatch to a semaphore to support alternate use cases. Use a Predicate to determine whether to throw a timeout exception. The previous implementation only accepted a Result message. Add some sanity checks to message processing.
Fixes #248.