### PR TITLE
Fix multi-byte assertion values.

### DIFF
--- a/core/src/main/java/org/ldaptive/filter/FilterUtils.java
+++ b/core/src/main/java/org/ldaptive/filter/FilterUtils.java
@@ -2,6 +2,7 @@
 package org.ldaptive.filter;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import org.ldaptive.LdapUtils;
 import org.ldaptive.ResultCode;
 
@@ -118,7 +119,17 @@ public final class FilterUtils
           throw new FilterParseException(ResultCode.FILTER_ERROR, "Could not hex decode escaped data in " + value, e);
         }
       } else {
-        bytes.write(c);
+        // CheckStyle:MagicNumber OFF
+        if ((c & 0x7F) == c) {
+          bytes.write(c);
+        } else {
+          try {
+            bytes.write(LdapUtils.utf8Encode(String.valueOf(c), false));
+          } catch (IOException e) {
+            throw new FilterParseException(ResultCode.FILTER_ERROR, "Could not write multi-byte character", e);
+          }
+        }
+        // CheckStyle:MagicNumber ON
       }
     }
     return bytes.toByteArray();

--- a/core/src/test/java/org/ldaptive/FilterTemplateTest.java
+++ b/core/src/test/java/org/ldaptive/FilterTemplateTest.java
@@ -83,6 +83,16 @@ public class FilterTemplateTest
             .parameter("firstname", "B\uD83D\uDF01ll")
             .build(),
         },
+        new Object[] {
+          "(member=uid=username," +
+            "ou=\\D0\\9B\\D0\\B0\\D0\\B1\\D0\\BE\\D1\\80\\D0\\B0\\D1\\82\\D0\\BE\\D1\\80\\D0\\B8\\D1\\8F," +
+            "ou=\\D0\\A3\\D0\\BD\\D0\\B8\\D0\\B2\\D0\\B5\\D1\\80\\D1\\81\\D0\\B8\\D1\\82\\D0\\B5\\D1\\82," +
+            "dc=company,dc=com)",
+          FilterTemplate.builder()
+            .filter("(member={dn})")
+            .parameter("dn", "uid=username,ou=Лаборатория,ou=Университет,dc=company,dc=com")
+            .build(),
+        },
       };
   }
 

--- a/core/src/test/java/org/ldaptive/filter/FilterFunctionTest.java
+++ b/core/src/test/java/org/ldaptive/filter/FilterFunctionTest.java
@@ -979,6 +979,19 @@ public class FilterFunctionTest
               new SubstringFilter("sub5", "5", "5", "5"))),
           false,
         },
+        new Object[] {
+          "(member=uid=username,ou=Лаборатория,ou=Университет,dc=company,dc=com)",
+          new EqualityFilter("member", "uid=username,ou=Лаборатория,ou=Университет,dc=company,dc=com"),
+          false,
+        },
+        new Object[] {
+          "(member=uid=username," +
+            "ou=\\D0\\9B\\D0\\B0\\D0\\B1\\D0\\BE\\D1\\80\\D0\\B0\\D1\\82\\D0\\BE\\D1\\80\\D0\\B8\\D1\\8F," +
+            "ou=\\D0\\A3\\D0\\BD\\D0\\B8\\D0\\B2\\D0\\B5\\D1\\80\\D1\\81\\D0\\B8\\D1\\82\\D0\\B5\\D1\\82," +
+            "dc=company,dc=com)",
+          new EqualityFilter("member", "uid=username,ou=Лаборатория,ou=Университет,dc=company,dc=com"),
+          false,
+        },
       };
   }
   // CheckStyle:MethodLength ON

--- a/core/src/test/java/org/ldaptive/filter/FilterUtilsTest.java
+++ b/core/src/test/java/org/ldaptive/filter/FilterUtilsTest.java
@@ -1,6 +1,7 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.ldaptive.filter;
 
+import org.ldaptive.LdapUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -80,6 +81,14 @@ public class FilterUtilsTest
           "Pirate Flag \uD83C\uDFF4\u200D\u2620\uFE0F",
           "Pirate Flag \\F0\\9F\\8F\\B4\\E2\\80\\8D\\E2\\98\\A0\\EF\\B8\\8F",
         },
+        new Object[] {
+          "Лаборатория",
+          "\\D0\\9B\\D0\\B0\\D0\\B1\\D0\\BE\\D1\\80\\D0\\B0\\D1\\82\\D0\\BE\\D1\\80\\D0\\B8\\D1\\8F",
+        },
+        new Object[] {
+          "Университет",
+          "\\D0\\A3\\D0\\BD\\D0\\B8\\D0\\B2\\D0\\B5\\D1\\80\\D1\\81\\D0\\B8\\D1\\82\\D0\\B5\\D1\\82",
+        },
       };
   }
 
@@ -91,9 +100,10 @@ public class FilterUtilsTest
    * @throws  Exception  On test failure.
    */
   @Test(dataProvider = "values")
-  public void escape(final String value, final String match)
+  public void escapeAndParse(final String value, final String match)
     throws Exception
   {
     Assert.assertEquals(FilterUtils.escape(value), match);
+    Assert.assertEquals(FilterUtils.parseAssertionValue(match), LdapUtils.utf8Encode(value));
   }
 }


### PR DESCRIPTION
FilterUtils was only writing the first byte of multi-byte characters. Fixes #252.