### PR TITLE
Prefer byte array over ByteBuffer for properties.

### DIFF
--- a/core/src/main/java/org/ldaptive/LdapEntry.java
+++ b/core/src/main/java/org/ldaptive/LdapEntry.java
@@ -1,7 +1,6 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.ldaptive;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -456,7 +455,7 @@ public class LdapEntry extends AbstractMessage
         getObject().addAttributes(LdapAttribute.builder().name(p.getName().get()).build());
       } else {
         getObject().addAttributes(
-          LdapAttribute.builder().name(p.getName().get()).bufferValues(p.getValues().get()).build());
+          LdapAttribute.builder().name(p.getName().get()).binaryValuesInternal(p.getValues().get()).build());
       }
     }
   }
@@ -481,7 +480,7 @@ public class LdapEntry extends AbstractMessage
     private String name;
 
     /** Attribute values. */
-    private List<ByteBuffer> values = new ArrayList<>();
+    private List<byte[]> values = new ArrayList<>();
 
 
     /**
@@ -490,7 +489,7 @@ public class LdapEntry extends AbstractMessage
     public AttributeParser()
     {
       parser.registerHandler(NAME_PATH, (p, e) -> name = OctetStringType.decode(e));
-      parser.registerHandler(VALUES_PATH, (p, e) -> values.add(ByteBuffer.wrap(e.getRemainingBytes())));
+      parser.registerHandler(VALUES_PATH, (p, e) -> values.add(e.getRemainingBytes()));
     }
 
 
@@ -521,7 +520,7 @@ public class LdapEntry extends AbstractMessage
      *
      * @return  attribute values or empty
      */
-    public Optional<List<ByteBuffer>> getValues()
+    public Optional<List<byte[]>> getValues()
     {
       return values.isEmpty() ? Optional.empty() : Optional.of(values);
     }

--- a/core/src/main/java/org/ldaptive/dn/NameValue.java
+++ b/core/src/main/java/org/ldaptive/dn/NameValue.java
@@ -1,7 +1,6 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.ldaptive.dn;
 
-import java.nio.ByteBuffer;
 import java.util.function.Function;
 import org.ldaptive.LdapUtils;
 
@@ -19,7 +18,7 @@ public class NameValue
   private final String attributeName;
 
   /** Attribute value. */
-  private final ByteBuffer attributeValue;
+  private final byte[] attributeValue;
 
 
   /**
@@ -43,7 +42,7 @@ public class NameValue
   public NameValue(final String name, final byte[] value)
   {
     attributeName = name;
-    attributeValue = value != null ? ByteBuffer.wrap(value) : null;
+    attributeValue = value;
   }
 
 
@@ -60,19 +59,19 @@ public class NameValue
 
   public byte[] getBinaryValue()
   {
-    return attributeValue != null ? attributeValue.array() : null;
+    return attributeValue;
   }
 
 
   public String getStringValue()
   {
-    return attributeValue != null ? LdapUtils.utf8Encode(attributeValue.array()) : null;
+    return attributeValue != null ? LdapUtils.utf8Encode(attributeValue) : null;
   }
 
 
   public <T> T getValue(final Function<byte[], T> func)
   {
-    return attributeValue != null ? func.apply(attributeValue.array()) : null;
+    return func.apply(getBinaryValue());
   }
 
 
@@ -96,7 +95,7 @@ public class NameValue
    */
   public String format()
   {
-    return attributeName + "=" + LdapUtils.utf8Encode(attributeValue != null ? attributeValue.array() : null);
+    return attributeName + "=" + LdapUtils.utf8Encode(attributeValue);
   }
 
 


### PR DESCRIPTION
Add AttributeValue to reduce complexity of LdapAttribute. Copy input and output byte arrays to guard against modification. Don't allow setting of null attribute type or value. Improve LdapAttribute test coverage.