### PR TITLE
Update response objects to support freeable.

### DIFF
--- a/core/src/main/java/org/ldaptive/AbstractResult.java
+++ b/core/src/main/java/org/ldaptive/AbstractResult.java
@@ -32,6 +32,9 @@ import org.ldaptive.asn1.OctetStringType;
 public abstract class AbstractResult extends AbstractMessage implements Result
 {
 
+  /** Referral URLS. */
+  private final List<String> referralURLs = new ArrayList<>();
+
   /** Result code. */
   private ResultCode resultCode;
 
@@ -41,47 +44,82 @@ public abstract class AbstractResult extends AbstractMessage implements Result
   /** Diagnostic message. */
   private String diagnosticMessage;
 
-  /** Referral URLS. */
-  private List<String> referralURLs = new ArrayList<>();
 
-
-  public ResultCode getResultCode()
+  /**
+   * Returns the result code.
+   *
+   * @return  result code
+   */
+  public final ResultCode getResultCode()
   {
     return resultCode;
   }
 
 
-  public void setResultCode(final ResultCode code)
+  /**
+   * Sets the result code.
+   *
+   * @param  code  result code
+   */
+  public final void setResultCode(final ResultCode code)
   {
+    assertMutableOnConstruct();
     resultCode = code;
   }
 
 
-  public String getMatchedDN()
+  /**
+   * Returns the matched DN.
+   *
+   * @return  matched DN
+   */
+  public final String getMatchedDN()
   {
     return matchedDN;
   }
 
 
-  public void setMatchedDN(final String dn)
+  /**
+   * Sets the matched DN.
+   *
+   * @param  dn  matched DN
+   */
+  public final void setMatchedDN(final String dn)
   {
+    assertMutableOnConstruct();
     matchedDN = dn;
   }
 
 
-  public String getDiagnosticMessage()
+  /**
+   * Returns the diagnostic message.
+   *
+   * @return  diagnostic message
+   */
+  public final String getDiagnosticMessage()
   {
     return diagnosticMessage;
   }
 
 
-  public void setDiagnosticMessage(final String message)
+  /**
+   * Sets the diagnostic message.
+   *
+   * @param  message  diagnostic message
+   */
+  public final void setDiagnosticMessage(final String message)
   {
+    assertMutableOnConstruct();
     diagnosticMessage = message;
   }
 
 
-  public String[] getReferralURLs()
+  /**
+   * Returns the referral URLs.
+   *
+   * @return  referral URLs
+   */
+  public final String[] getReferralURLs()
   {
     return referralURLs != null ? referralURLs.toArray(new String[0]) : null;
   }
@@ -92,8 +130,9 @@ public abstract class AbstractResult extends AbstractMessage implements Result
    *
    * @param  urls  to add
    */
-  public void addReferralURLs(final String... urls)
+  public final void addReferralURLs(final String... urls)
   {
+    assertMutableOnConstruct();
     Collections.addAll(referralURLs, urls);
   }
 
@@ -111,6 +150,29 @@ public abstract class AbstractResult extends AbstractMessage implements Result
     setMatchedDN(result.getMatchedDN());
     setDiagnosticMessage(result.getDiagnosticMessage());
     addReferralURLs(result.getReferralURLs());
+  }
+
+
+  /**
+   * Returns whether the base properties of this result are equal. Those include message ID, controls, result code,
+   * matched DN, diagnostic message and referral URLs.
+   *
+   * @param  result  to compare
+   *
+   * @return  whether result properties are equal
+   */
+  public final boolean equalsResult(final Result result)
+  {
+    if (result == this) {
+      return true;
+    }
+    if (super.equalsMessage(result)) {
+      return LdapUtils.areEqual(getResultCode(), result.getResultCode()) &&
+        LdapUtils.areEqual(getMatchedDN(), result.getMatchedDN()) &&
+        LdapUtils.areEqual(getDiagnosticMessage(), result.getDiagnosticMessage()) &&
+        LdapUtils.areEqual(getReferralURLs(), result.getReferralURLs());
+    }
+    return false;
   }
 
 

--- a/core/src/main/java/org/ldaptive/AddResponse.java
+++ b/core/src/main/java/org/ldaptive/AddResponse.java
@@ -14,7 +14,7 @@ import org.ldaptive.asn1.DERPath;
  *
  * @author  Middleware Services
  */
-public class AddResponse extends AbstractResult
+public final class AddResponse extends AbstractResult
 {
 
   /** BER protocol number. */
@@ -57,6 +57,7 @@ public class AddResponse extends AbstractResult
     parser.registerHandler(REFERRAL_PATH, new ReferralHandler(this));
     parser.registerHandler(ControlsHandler.PATH, new ControlsHandler(this));
     parser.parse(buffer);
+    freezeOnConstruct();
   }
 
 
@@ -97,11 +98,11 @@ public class AddResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, AddResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, AddResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new AddResponse());
     }

--- a/core/src/main/java/org/ldaptive/BindResponse.java
+++ b/core/src/main/java/org/ldaptive/BindResponse.java
@@ -17,7 +17,7 @@ import org.ldaptive.asn1.DERPath;
  *
  * @author  Middleware Services
  */
-public class BindResponse extends AbstractResult
+public final class BindResponse extends AbstractResult
 {
 
   /** BER protocol number. */
@@ -67,6 +67,7 @@ public class BindResponse extends AbstractResult
     parser.registerHandler(SASL_CREDENTIALS_PATH, new SASLCredsHandler(this));
     parser.registerHandler(ControlsHandler.PATH, new ControlsHandler(this));
     parser.parse(buffer);
+    freezeOnConstruct();
   }
 
 
@@ -78,6 +79,7 @@ public class BindResponse extends AbstractResult
 
   public void setServerSaslCreds(final byte[] creds)
   {
+    assertMutableOnConstruct();
     serverSaslCreds = creds;
   }
 
@@ -150,11 +152,11 @@ public class BindResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, BindResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, BindResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new BindResponse());
     }

--- a/core/src/main/java/org/ldaptive/CompareResponse.java
+++ b/core/src/main/java/org/ldaptive/CompareResponse.java
@@ -14,7 +14,7 @@ import org.ldaptive.asn1.DERPath;
  *
  * @author  Middleware Services
  */
-public class CompareResponse extends AbstractResult
+public final class CompareResponse extends AbstractResult
 {
 
   /** BER protocol number. */
@@ -57,6 +57,7 @@ public class CompareResponse extends AbstractResult
     parser.registerHandler(REFERRAL_PATH, new ReferralHandler(this));
     parser.registerHandler(ControlsHandler.PATH, new ControlsHandler(this));
     parser.parse(buffer);
+    freezeOnConstruct();
   }
 
 
@@ -119,11 +120,11 @@ public class CompareResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, CompareResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, CompareResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new CompareResponse());
     }

--- a/core/src/main/java/org/ldaptive/DeleteResponse.java
+++ b/core/src/main/java/org/ldaptive/DeleteResponse.java
@@ -14,7 +14,7 @@ import org.ldaptive.asn1.DERPath;
  *
  * @author  Middleware Services
  */
-public class DeleteResponse extends AbstractResult
+public final class DeleteResponse extends AbstractResult
 {
 
   /** BER protocol number. */
@@ -57,6 +57,7 @@ public class DeleteResponse extends AbstractResult
     parser.registerHandler(REFERRAL_PATH, new ReferralHandler(this));
     parser.registerHandler(ControlsHandler.PATH, new ControlsHandler(this));
     parser.parse(buffer);
+    freezeOnConstruct();
   }
 
 
@@ -97,11 +98,11 @@ public class DeleteResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, DeleteResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, DeleteResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new DeleteResponse());
     }

--- a/core/src/main/java/org/ldaptive/LdapEntry.java
+++ b/core/src/main/java/org/ldaptive/LdapEntry.java
@@ -3,6 +3,7 @@ package org.ldaptive;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -50,6 +51,9 @@ public class LdapEntry extends AbstractMessage
   /** DER path to attributes. */
   private static final DERPath ATTRIBUTES_PATH = new DERPath("/SEQ/APP(4)/SEQ/SEQ");
 
+  /** LDAP attributes on the entry. */
+  private final Map<String, LdapAttribute> attributes = new LinkedHashMap<>();
+
   /** LDAP DN of the entry. */
   private String ldapDn;
 
@@ -58,9 +62,6 @@ public class LdapEntry extends AbstractMessage
 
   /** Normalized LDAP DN. */
   private String normalizedDn;
-
-  /** LDAP attributes on the entry. */
-  private Map<String, LdapAttribute> attributes = new LinkedHashMap<>();
 
 
   /**
@@ -82,6 +83,18 @@ public class LdapEntry extends AbstractMessage
     parser.registerHandler(ATTRIBUTES_PATH, new AttributesHandler(this));
     parser.registerHandler(ControlsHandler.PATH, new ControlsHandler(this));
     parser.parse(buffer);
+    freezeOnConstruct();
+  }
+
+
+  @Override
+  public void freeze()
+  {
+    super.freeze();
+    if (parsedDn != null) {
+      parsedDn.freeze();
+    }
+    attributes.values().forEach(a -> a.freeze());
   }
 
 
@@ -90,7 +103,7 @@ public class LdapEntry extends AbstractMessage
    *
    * @return  ldap DN
    */
-  public String getDn()
+  public final String getDn()
   {
     return ldapDn;
   }
@@ -101,7 +114,7 @@ public class LdapEntry extends AbstractMessage
    *
    * @return  parsed ldap DN or null if {@link #ldapDn} is null or could not be parsed
    */
-  public Dn getParsedDn()
+  public final Dn getParsedDn()
   {
     return parsedDn;
   }
@@ -112,7 +125,7 @@ public class LdapEntry extends AbstractMessage
    *
    * @return  normalized ldap DN or null if {@link #ldapDn} is null or could not be parsed
    */
-  public String getNormalizedDn()
+  public final String getNormalizedDn()
   {
     return normalizedDn;
   }
@@ -123,8 +136,9 @@ public class LdapEntry extends AbstractMessage
    *
    * @param  dn  ldap DN
    */
-  public void setDn(final String dn)
+  public final void setDn(final String dn)
   {
+    assertMutable();
     ldapDn = dn;
     if (ldapDn != null) {
       try {
@@ -146,7 +160,7 @@ public class LdapEntry extends AbstractMessage
    */
   public Collection<LdapAttribute> getAttributes()
   {
-    return attributes.values();
+    return Collections.unmodifiableCollection(attributes.values());
   }
 
 
@@ -199,6 +213,7 @@ public class LdapEntry extends AbstractMessage
    */
   public void addAttributes(final LdapAttribute... attrs)
   {
+    assertMutable();
     for (LdapAttribute a : attrs) {
       attributes.put(LdapUtils.toLowerCase(a.getName()), a);
     }
@@ -212,6 +227,7 @@ public class LdapEntry extends AbstractMessage
    */
   public void addAttributes(final Collection<LdapAttribute> attrs)
   {
+    assertMutable();
     attrs.forEach(a -> attributes.put(LdapUtils.toLowerCase(a.getName()), a));
   }
 
@@ -223,6 +239,7 @@ public class LdapEntry extends AbstractMessage
    */
   public void removeAttribute(final String name)
   {
+    assertMutable();
     attributes.remove(LdapUtils.toLowerCase(name));
   }
 
@@ -234,6 +251,7 @@ public class LdapEntry extends AbstractMessage
    */
   public void removeAttributes(final LdapAttribute... attrs)
   {
+    assertMutable();
     for (LdapAttribute a : attrs) {
       attributes.remove(LdapUtils.toLowerCase(a.getName()));
     }
@@ -247,6 +265,7 @@ public class LdapEntry extends AbstractMessage
    */
   public void removeAttributes(final Collection<LdapAttribute> attrs)
   {
+    assertMutable();
     attrs.forEach(a -> attributes.remove(LdapUtils.toLowerCase(a.getName())));
   }
 
@@ -256,15 +275,16 @@ public class LdapEntry extends AbstractMessage
    *
    * @return  number of attributes
    */
-  public int size()
+  public final int size()
   {
     return attributes.size();
   }
 
 
   /** Removes all the attributes. */
-  public void clear()
+  public final void clear()
   {
+    assertMutable();
     attributes.clear();
   }
 
@@ -310,6 +330,27 @@ public class LdapEntry extends AbstractMessage
 
 
   /**
+   * Creates a mutable copy of the supplied entry.
+   *
+   * @param  entry  to copy
+   *
+   * @return  new ldap entry instance
+   */
+  public static LdapEntry copy(final LdapEntry entry)
+  {
+    final LdapEntry copy = new LdapEntry();
+    copy.copyValues(entry);
+    copy.ldapDn = entry.ldapDn;
+    copy.parsedDn = entry.parsedDn != null ? Dn.copy(entry.parsedDn) : null;
+    copy.normalizedDn = entry.normalizedDn;
+    for (Map.Entry<String, LdapAttribute> e : entry.attributes.entrySet()) {
+      copy.attributes.put(e.getKey(), LdapAttribute.copy(e.getValue()));
+    }
+    return copy;
+  }
+
+
+  /**
    * Returns a new entry whose attributes are sorted naturally by name without options.
    *
    * @param  le  entry to sort
@@ -325,6 +366,9 @@ public class LdapEntry extends AbstractMessage
       le.getAttributes().stream()
         .map(LdapAttribute::sort)
         .sorted(Comparator.comparing(o -> o.getName(false))).collect(Collectors.toCollection(LinkedHashSet::new)));
+    if (le.isFrozen()) {
+      sorted.freeze();
+    }
     return sorted;
   }
 

--- a/core/src/main/java/org/ldaptive/ModifyDnResponse.java
+++ b/core/src/main/java/org/ldaptive/ModifyDnResponse.java
@@ -14,7 +14,7 @@ import org.ldaptive.asn1.DERPath;
  *
  * @author  Middleware Services
  */
-public class ModifyDnResponse extends AbstractResult
+public final class ModifyDnResponse extends AbstractResult
 {
 
   /** BER protocol number. */
@@ -57,6 +57,7 @@ public class ModifyDnResponse extends AbstractResult
     parser.registerHandler(REFERRAL_PATH, new ReferralHandler(this));
     parser.registerHandler(ControlsHandler.PATH, new ControlsHandler(this));
     parser.parse(buffer);
+    freezeOnConstruct();
   }
 
 
@@ -97,11 +98,11 @@ public class ModifyDnResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, ModifyDnResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, ModifyDnResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new ModifyDnResponse());
     }

--- a/core/src/main/java/org/ldaptive/ModifyResponse.java
+++ b/core/src/main/java/org/ldaptive/ModifyResponse.java
@@ -14,7 +14,7 @@ import org.ldaptive.asn1.DERPath;
  *
  * @author  Middleware Services
  */
-public class ModifyResponse extends AbstractResult
+public final class ModifyResponse extends AbstractResult
 {
 
   /** BER protocol number. */
@@ -57,6 +57,7 @@ public class ModifyResponse extends AbstractResult
     parser.registerHandler(REFERRAL_PATH, new ReferralHandler(this));
     parser.registerHandler(ControlsHandler.PATH, new ControlsHandler(this));
     parser.parse(buffer);
+    freezeOnConstruct();
   }
 
 
@@ -97,11 +98,11 @@ public class ModifyResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, ModifyResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, ModifyResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new ModifyResponse());
     }

--- a/core/src/main/java/org/ldaptive/SearchResultReference.java
+++ b/core/src/main/java/org/ldaptive/SearchResultReference.java
@@ -23,7 +23,7 @@ import org.ldaptive.asn1.OctetStringType;
  *
  * @author  Middleware Services
  */
-public class SearchResultReference extends AbstractMessage
+public final class SearchResultReference extends AbstractMessage
 {
 
   /** BER protocol number. */
@@ -36,7 +36,7 @@ public class SearchResultReference extends AbstractMessage
   private static final DERPath REFERRAL_URI_PATH = new DERPath("/SEQ/APP(19)/OCTSTR");
 
   /** List of references. */
-  private List<String> references = new ArrayList<>();
+  private final List<String> references = new ArrayList<>();
 
 
   /**
@@ -57,9 +57,15 @@ public class SearchResultReference extends AbstractMessage
     parser.registerHandler(REFERRAL_URI_PATH, new ReferralUriHandler(this));
     parser.registerHandler(ControlsHandler.PATH, new ControlsHandler(this));
     parser.parse(buffer);
+    freezeOnConstruct();
   }
 
 
+  /**
+   * Returns the URIs in this reference.
+   *
+   * @return  reference URIs
+   */
   public String[] getUris()
   {
     return references.toArray(new String[0]);
@@ -73,6 +79,7 @@ public class SearchResultReference extends AbstractMessage
    */
   public void addUris(final String... uri)
   {
+    assertMutable();
     Collections.addAll(references, uri);
   }
 
@@ -84,7 +91,34 @@ public class SearchResultReference extends AbstractMessage
    */
   public void addUris(final Collection<String> uris)
   {
+    assertMutable();
     references.addAll(uris);
+  }
+
+
+  /**
+   * Removes a URI from this reference.
+   *
+   * @param  uri  to remove
+   */
+  public void removeUris(final String... uri)
+  {
+    assertMutable();
+    for (String s : uri) {
+      references.remove(s);
+    }
+  }
+
+
+  /**
+   * Removes a URI from this reference.
+   *
+   * @param  uris  to remove
+   */
+  public void removeUris(final Collection<String> uris)
+  {
+    assertMutable();
+    uris.forEach(references::remove);
   }
 
 
@@ -118,6 +152,22 @@ public class SearchResultReference extends AbstractMessage
   public String toString()
   {
     return super.toString() + ", " + "URIs=" + references;
+  }
+
+
+  /**
+   * Creates a mutable copy of the supplied search result reference.
+   *
+   * @param  ref  to copy
+   *
+   * @return  new search result reference instance
+   */
+  public static SearchResultReference copy(final SearchResultReference ref)
+  {
+    final SearchResultReference copy = new SearchResultReference();
+    copy.copyValues(ref);
+    copy.references.addAll(ref.references);
+    return copy;
   }
 
 
@@ -173,11 +223,11 @@ public class SearchResultReference extends AbstractMessage
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractMessage.AbstractBuilder<Builder, SearchResultReference>
+  public static final class Builder extends AbstractMessage.AbstractBuilder<Builder, SearchResultReference>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new SearchResultReference());
     }

--- a/core/src/main/java/org/ldaptive/auth/AuthenticationHandlerResponse.java
+++ b/core/src/main/java/org/ldaptive/auth/AuthenticationHandlerResponse.java
@@ -12,7 +12,7 @@ import org.ldaptive.Result;
  *
  * @author  Middleware Services
  */
-public class AuthenticationHandlerResponse extends AbstractResult
+public final class AuthenticationHandlerResponse extends AbstractResult
 {
 
   /** hash code seed. */
@@ -45,6 +45,7 @@ public class AuthenticationHandlerResponse extends AbstractResult
     copyValues(result);
     authenticationResultCode = code;
     connection = conn;
+    freezeOnConstruct();
   }
 
 
@@ -120,18 +121,18 @@ public class AuthenticationHandlerResponse extends AbstractResult
    *
    * @return  new builder
    */
-  protected static Builder builder()
+  static Builder builder()
   {
     return new Builder();
   }
 
 
   // CheckStyle:OFF
-  protected static class Builder extends AbstractResult.AbstractBuilder<Builder, AuthenticationHandlerResponse>
+  protected static final class Builder extends AbstractResult.AbstractBuilder<Builder, AuthenticationHandlerResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new AuthenticationHandlerResponse());
     }

--- a/core/src/main/java/org/ldaptive/auth/AuthenticationResponse.java
+++ b/core/src/main/java/org/ldaptive/auth/AuthenticationResponse.java
@@ -11,7 +11,7 @@ import org.ldaptive.LdapUtils;
  *
  * @author  Middleware Services
  */
-public class AuthenticationResponse extends AbstractResult
+public final class AuthenticationResponse extends AbstractResult
 {
 
   /** hash code seed. */
@@ -50,6 +50,8 @@ public class AuthenticationResponse extends AbstractResult
     authenticationHandlerResponse = response;
     resolvedDn = dn;
     ldapEntry = entry;
+    ldapEntry.freeze();
+    freezeOnConstruct();
   }
 
 
@@ -119,6 +121,7 @@ public class AuthenticationResponse extends AbstractResult
    */
   public void setAccountState(final AccountState state)
   {
+    // account state must remain mutable for response handlers
     accountState = state;
   }
 
@@ -182,18 +185,18 @@ public class AuthenticationResponse extends AbstractResult
    *
    * @return  new builder
    */
-  protected static Builder builder()
+  static Builder builder()
   {
     return new Builder();
   }
 
 
   // CheckStyle:OFF
-  protected static class Builder extends AbstractResult.AbstractBuilder<Builder, AuthenticationResponse>
+  protected static final class Builder extends AbstractResult.AbstractBuilder<Builder, AuthenticationResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new AuthenticationResponse());
     }

--- a/core/src/main/java/org/ldaptive/auth/NoOpEntryResolver.java
+++ b/core/src/main/java/org/ldaptive/auth/NoOpEntryResolver.java
@@ -15,7 +15,7 @@ public final class NoOpEntryResolver implements EntryResolver
   @Override
   public LdapEntry resolve(final AuthenticationCriteria criteria, final AuthenticationHandlerResponse response)
   {
-    return LdapEntry.builder().dn(criteria.getDn()).build();
+    return LdapEntry.builder().dn(criteria.getDn()).freeze().build();
   }
 
 

--- a/core/src/main/java/org/ldaptive/control/util/PagedResultsClient.java
+++ b/core/src/main/java/org/ldaptive/control/util/PagedResultsClient.java
@@ -12,8 +12,6 @@ import org.ldaptive.SearchRequest;
 import org.ldaptive.SearchResponse;
 import org.ldaptive.control.PagedResultsControl;
 import org.ldaptive.control.RequestControl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Client that simplifies using the paged results control.
@@ -22,9 +20,6 @@ import org.slf4j.LoggerFactory;
  */
 public class PagedResultsClient extends AbstractSearchOperationFactory
 {
-
-  /** Logger for this class. */
-  protected final Logger logger = LoggerFactory.getLogger(getClass());
 
   /** Results page size. */
   private final int resultSize;
@@ -226,9 +221,11 @@ public class PagedResultsClient extends AbstractSearchOperationFactory
         manager.writeCookie(cookie);
       }
     } while (cookie != null);
-    result.addEntries(combinedResults.getEntries());
-    result.addReferences(combinedResults.getReferences());
-    return result;
+    final SearchResponse finalResult = SearchResponse.copy(result);
+    finalResult.addEntries(combinedResults.getEntries());
+    finalResult.addReferences(combinedResults.getReferences());
+    finalResult.freeze();
+    return finalResult;
   }
 
 

--- a/core/src/main/java/org/ldaptive/dn/NameValue.java
+++ b/core/src/main/java/org/ldaptive/dn/NameValue.java
@@ -9,7 +9,7 @@ import org.ldaptive.LdapUtils;
  *
  * @author  Middleware Services
  */
-public class NameValue
+public final class NameValue
 {
   /** hash code seed. */
   private static final int HASH_CODE_SEED = 5011;

--- a/core/src/main/java/org/ldaptive/dn/RDn.java
+++ b/core/src/main/java/org/ldaptive/dn/RDn.java
@@ -21,7 +21,7 @@ import org.ldaptive.LdapUtils;
  *
  * @author  Middleware Services
  */
-public class RDn
+public final class RDn
 {
 
   /** hash code seed. */

--- a/core/src/main/java/org/ldaptive/extended/ExtendedResponse.java
+++ b/core/src/main/java/org/ldaptive/extended/ExtendedResponse.java
@@ -79,29 +79,32 @@ public class ExtendedResponse extends AbstractResult
     parser.registerHandler(VALUE_PATH, new ResponseValueHandler(this));
     parser.registerHandler(ControlsHandler.PATH, new ControlsHandler(this));
     parser.parse(buffer);
+    freezeOnConstruct();
   }
 
 
-  public String getResponseName()
+  public final String getResponseName()
   {
     return responseName;
   }
 
 
-  public void setResponseName(final String name)
+  public final void setResponseName(final String name)
   {
+    assertMutableOnConstruct();
     responseName = name;
   }
 
 
-  public byte[] getResponseValue()
+  public final byte[] getResponseValue()
   {
     return responseValue;
   }
 
 
-  public void setResponseValue(final byte[] value)
+  public final void setResponseValue(final byte[] value)
   {
+    assertMutableOnConstruct();
     responseValue = value;
   }
 

--- a/core/src/main/java/org/ldaptive/extended/IntermediateResponse.java
+++ b/core/src/main/java/org/ldaptive/extended/IntermediateResponse.java
@@ -56,29 +56,32 @@ public class IntermediateResponse extends AbstractMessage
     parser.registerHandler(ResponseValueHandler.PATH, new ResponseValueHandler(this));
     parser.registerHandler(ControlsHandler.PATH, new ControlsHandler(this));
     parser.parse(buffer);
+    freezeOnConstruct();
   }
 
 
-  public String getResponseName()
+  public final String getResponseName()
   {
     return responseName;
   }
 
 
-  protected void setResponseName(final String name)
+  protected final void setResponseName(final String name)
   {
+    assertMutableOnConstruct();
     responseName = name;
   }
 
 
-  public byte[] getResponseValue()
+  public final byte[] getResponseValue()
   {
     return responseValue;
   }
 
 
-  protected void setResponseValue(final byte[] value)
+  protected final void setResponseValue(final byte[] value)
   {
+    assertMutableOnConstruct();
     responseValue = value;
   }
 

--- a/core/src/main/java/org/ldaptive/extended/NoticeOfDisconnection.java
+++ b/core/src/main/java/org/ldaptive/extended/NoticeOfDisconnection.java
@@ -18,7 +18,7 @@ import org.ldaptive.asn1.DERBuffer;
  *
  * @author  Middleware Services
  */
-public class NoticeOfDisconnection extends UnsolicitedNotification
+public final class NoticeOfDisconnection extends UnsolicitedNotification
 {
 
   /** OID of this response. */
@@ -87,11 +87,11 @@ public class NoticeOfDisconnection extends UnsolicitedNotification
 
 
   // CheckStyle:OFF
-  public static class Builder extends UnsolicitedNotification.Builder
+  public static final class Builder extends UnsolicitedNotification.Builder
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new NoticeOfDisconnection());
     }

--- a/core/src/main/java/org/ldaptive/extended/SyncInfoMessage.java
+++ b/core/src/main/java/org/ldaptive/extended/SyncInfoMessage.java
@@ -44,7 +44,7 @@ import org.ldaptive.control.ResponseControl;
  *
  * @author  Middleware Services
  */
-public class SyncInfoMessage extends IntermediateResponse
+public final class SyncInfoMessage extends IntermediateResponse
 {
 
   /** OID of this response. */
@@ -102,6 +102,9 @@ public class SyncInfoMessage extends IntermediateResponse
     SYNC_ID_SET
   }
 
+  /** entry uuids. */
+  private final Set<UUID> entryUuids = new LinkedHashSet<>();
+
   /** message type. */
   private Type messageType;
 
@@ -114,14 +117,11 @@ public class SyncInfoMessage extends IntermediateResponse
   /** refresh deletes. */
   private boolean refreshDeletes;
 
-  /** entry uuids. */
-  private Set<UUID> entryUuids = new LinkedHashSet<>();
-
 
   /**
    * Default constructor.
    */
-  protected SyncInfoMessage()
+  private SyncInfoMessage()
   {
     setResponseName(OID);
   }
@@ -140,10 +140,11 @@ public class SyncInfoMessage extends IntermediateResponse
     parser.registerHandler(ResponseValueHandler.PATH, getResponseValueParseHandler());
     parser.registerHandler(ControlsHandler.PATH, new ControlsHandler(this));
     parser.parse(buffer);
+    freezeOnConstruct();
   }
 
 
-  protected ParseHandler getResponseValueParseHandler()
+  private ParseHandler getResponseValueParseHandler()
   {
     return (parser, encoded) -> {
       final DERParser p = new DERParser();
@@ -181,6 +182,7 @@ public class SyncInfoMessage extends IntermediateResponse
    */
   public void setMessageType(final Type type)
   {
+    assertMutableOnConstruct();
     messageType = type;
   }
 
@@ -203,6 +205,7 @@ public class SyncInfoMessage extends IntermediateResponse
    */
   public void setCookie(final byte[] value)
   {
+    assertMutableOnConstruct();
     cookie = value;
   }
 
@@ -225,6 +228,7 @@ public class SyncInfoMessage extends IntermediateResponse
    */
   public void setRefreshDone(final boolean b)
   {
+    assertMutableOnConstruct();
     refreshDone = b;
   }
 
@@ -247,6 +251,7 @@ public class SyncInfoMessage extends IntermediateResponse
    */
   public void setRefreshDeletes(final boolean b)
   {
+    assertMutableOnConstruct();
     refreshDeletes = b;
   }
 
@@ -269,6 +274,7 @@ public class SyncInfoMessage extends IntermediateResponse
    */
   public void addEntryUuids(final UUID... uuids)
   {
+    assertMutableOnConstruct();
     Collections.addAll(entryUuids, uuids);
   }
 
@@ -611,17 +617,17 @@ public class SyncInfoMessage extends IntermediateResponse
 
 
   // CheckStyle:OFF
-  public static class Builder extends IntermediateResponse.Builder
+  public static final class Builder extends IntermediateResponse.Builder
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new SyncInfoMessage());
     }
 
 
-    protected Builder(final SyncInfoMessage m)
+    private Builder(final SyncInfoMessage m)
     {
       super(m);
     }

--- a/core/src/main/java/org/ldaptive/extended/UnsolicitedNotification.java
+++ b/core/src/main/java/org/ldaptive/extended/UnsolicitedNotification.java
@@ -48,6 +48,7 @@ public class UnsolicitedNotification extends ExtendedResponse
   @Override
   public void setMessageID(final int id)
   {
+    assertMutableOnConstruct();
     if (id != 0) {
       throw new IllegalArgumentException("Message ID must be zero");
     }

--- a/core/src/main/java/org/ldaptive/transport/DefaultCompareOperationHandle.java
+++ b/core/src/main/java/org/ldaptive/transport/DefaultCompareOperationHandle.java
@@ -23,7 +23,7 @@ import org.ldaptive.handler.UnsolicitedNotificationHandler;
  *
  * @author  Middleware Services
  */
-public class DefaultCompareOperationHandle
+public final class DefaultCompareOperationHandle
   extends DefaultOperationHandle<CompareRequest, CompareResponse> implements CompareOperationHandle
 {
 

--- a/core/src/main/java/org/ldaptive/transport/DefaultExtendedOperationHandle.java
+++ b/core/src/main/java/org/ldaptive/transport/DefaultExtendedOperationHandle.java
@@ -22,7 +22,7 @@ import org.ldaptive.handler.UnsolicitedNotificationHandler;
  *
  * @author  Middleware Services
  */
-public class DefaultExtendedOperationHandle
+public final class DefaultExtendedOperationHandle
   extends DefaultOperationHandle<ExtendedRequest, ExtendedResponse> implements ExtendedOperationHandle
 {
 

--- a/core/src/main/java/org/ldaptive/transport/netty/NettyConnection.java
+++ b/core/src/main/java/org/ldaptive/transport/netty/NettyConnection.java
@@ -1282,7 +1282,7 @@ public final class NettyConnection extends TransportConnection
 
 
   /** Bind specific operation handle that locks other operations until the bind completes. */
-  public class BindOperationHandle extends DefaultOperationHandle<BindRequest, BindResponse>
+  public final class BindOperationHandle extends DefaultOperationHandle<BindRequest, BindResponse>
   {
 
 

--- a/core/src/test/java/org/ldaptive/EqualsTest.java
+++ b/core/src/test/java/org/ldaptive/EqualsTest.java
@@ -130,6 +130,7 @@ public class EqualsTest
     EqualsVerifier.forClass(SearchResultReference.class)
       .suppress(Warning.STRICT_INHERITANCE)
       .suppress(Warning.NONFINAL_FIELDS)
+      .withIgnoredFields("immutableOnConstruct", "immutable")
       .verify();
   }
 
@@ -170,6 +171,7 @@ public class EqualsTest
     EqualsVerifier.forClass(clazz)
       .suppress(Warning.STRICT_INHERITANCE)
       .suppress(Warning.NONFINAL_FIELDS)
+      .withIgnoredFields("immutableOnConstruct", "immutable")
       .verify();
   }
 }

--- a/core/src/test/java/org/ldaptive/FreezableTest.java
+++ b/core/src/test/java/org/ldaptive/FreezableTest.java
@@ -5,14 +5,19 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import org.ldaptive.ad.handler.ObjectGuidHandler;
 import org.ldaptive.ad.handler.ObjectSidHandler;
 import org.ldaptive.ad.handler.PrimaryGroupIdHandler;
 import org.ldaptive.ad.handler.RangeEntryHandler;
+import org.ldaptive.auth.AccountState;
 import org.ldaptive.auth.AggregateAuthenticationHandler;
 import org.ldaptive.auth.AggregateAuthenticationResponseHandler;
 import org.ldaptive.auth.AggregateDnResolver;
 import org.ldaptive.auth.AggregateEntryResolver;
+import org.ldaptive.auth.AuthenticationHandlerResponse;
+import org.ldaptive.auth.AuthenticationResponse;
 import org.ldaptive.auth.Authenticator;
 import org.ldaptive.auth.AuthorizationIdentityEntryResolver;
 import org.ldaptive.auth.CompareAuthenticationHandler;
@@ -27,6 +32,12 @@ import org.ldaptive.auth.ext.FreeIPAAuthenticationResponseHandler;
 import org.ldaptive.control.SortKey;
 import org.ldaptive.control.util.PagedResultsClient;
 import org.ldaptive.control.util.VirtualListViewClient;
+import org.ldaptive.dn.Dn;
+import org.ldaptive.extended.ExtendedResponse;
+import org.ldaptive.extended.IntermediateResponse;
+import org.ldaptive.extended.NoticeOfDisconnection;
+import org.ldaptive.extended.SyncInfoMessage;
+import org.ldaptive.extended.UnsolicitedNotification;
 import org.ldaptive.handler.CaseChangeEntryHandler;
 import org.ldaptive.handler.DnAttributeEntryHandler;
 import org.ldaptive.handler.MergeAttributeEntryHandler;
@@ -50,6 +61,17 @@ import org.testng.annotations.Test;
 public class FreezableTest
 {
 
+  /** Methods to ignore immutability test. */
+  private static final List<Method> IGNORE_METHODS = new ArrayList<>();
+
+  /* Initialize ignore methods. */
+  static {
+    try {
+      IGNORE_METHODS.add(AuthenticationResponse.class.getMethod("setAccountState", AccountState.class));
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   /**
    * Immutable classes.
@@ -101,6 +123,57 @@ public class FreezableTest
           SearchConnectionValidator.class,
         },
         new Object[] {
+          AddResponse.class,
+        },
+        new Object[] {
+          AuthenticationHandlerResponse.class,
+        },
+        new Object[] {
+          AuthenticationResponse.class,
+        },
+        new Object[] {
+          BindResponse.class,
+        },
+        new Object[] {
+          CompareResponse.class,
+        },
+        new Object[] {
+          DeleteResponse.class,
+        },
+        new Object[] {
+          ExtendedResponse.class,
+        },
+        new Object[] {
+          UnsolicitedNotification.class,
+        },
+        new Object[] {
+          NoticeOfDisconnection.class,
+        },
+        new Object[] {
+          ModifyDnResponse.class,
+        },
+        new Object[] {
+          ModifyResponse.class,
+        },
+        new Object[] {
+          SearchResponse.class,
+        },
+        new Object[] {
+          IntermediateResponse.class,
+        },
+        new Object[] {
+          SyncInfoMessage.class,
+        },
+        new Object[] {
+          LdapEntry.class,
+        },
+        new Object[] {
+          LdapAttribute.class,
+        },
+        new Object[] {
+          SearchResultReference.class,
+        },
+        new Object[] {
           IdlePruneStrategy.class,
         },
         new Object[] {
@@ -147,6 +220,9 @@ public class FreezableTest
         },
         new Object[] {
           SingleConnectionFactory.class,
+        },
+        new Object[] {
+          Dn.class,
         },
         new Object[] {
           EDirectoryAuthenticationResponseHandler.class,
@@ -197,6 +273,9 @@ public class FreezableTest
     final Constructor<? extends Freezable> constructor = clazz.getDeclaredConstructor();
     constructor.setAccessible(true);
     final Freezable i = constructor.newInstance();
+    if (i instanceof AbstractMessage) {
+      ((AbstractMessage) i).freezeOnConstruct();
+    }
     i.freeze();
     invokeMethods(clazz, i);
   }
@@ -225,7 +304,7 @@ public class FreezableTest
   private void invokeMethods(final Class<? extends Freezable> clazz, final Freezable i)
   {
     for (Method method : clazz.getMethods()) {
-      if (!method.isBridge()) {
+      if (!IGNORE_METHODS.contains(method) && !method.isBridge()) {
         final boolean invokeMethod =
           (method.getName().startsWith("set") || method.getName().startsWith("add")) &&
             method.getParameterTypes().length == 1;

--- a/core/src/test/java/org/ldaptive/SearchResponseTest.java
+++ b/core/src/test/java/org/ldaptive/SearchResponseTest.java
@@ -679,4 +679,179 @@ public class SearchResponseTest
         .reference(SearchResultReference.builder().uris("ldap://directory-3.ldaptive.org").build())
         .build());
   }
+
+
+  @Test
+  public void immutable()
+  {
+    final SearchResponse response = SearchResponse.builder()
+      .messageID(1)
+      .controls(new SortResponseControl())
+      .entry(
+        LdapEntry.builder()
+          .messageID(1)
+          .dn("uid=1,ou=people,dc=ldaptive,dc=org")
+          .attributes(LdapAttribute.builder().name("givenName").values("bob", "robert").build())
+          .attributes(LdapAttribute.builder().name("sn").values("baker").build())
+          .build())
+      .reference(
+        SearchResultReference.builder()
+          .messageID(1)
+          .uris("ldap://ds1.ldaptive.org", "ldap://ds2.ldaptive.org")
+          .build())
+      .build();
+
+    response.assertMutable();
+    try {
+      response.setMessageID(0);
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    try {
+      response.addControls(new SortResponseControl());
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    try {
+      response.setDiagnosticMessage("foo");
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    try {
+      response.setMatchedDN("bar");
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    try {
+      response.setResultCode(ResultCode.LOCAL_ERROR);
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    response.addEntries(
+      LdapEntry.builder()
+        .messageID(1)
+        .dn("uid=2,ou=people,dc=ldaptive,dc=org")
+        .attributes(LdapAttribute.builder().name("givenName").values("bill", "billy").build())
+        .attributes(LdapAttribute.builder().name("sn").values("thompson").build())
+        .build());
+    response.addReferences(SearchResultReference.builder().uris("ldap://ds3.ldaptive.org").build());
+    response.getEntry().setDn("uid=1,ou=robots,dc=ldaptive,dc=org");
+    response.getEntry().getAttribute("givenName").addStringValues("rob");
+
+    response.freeze();
+    try {
+      response.addEntries(LdapEntry.builder()
+        .messageID(1)
+        .dn("uid=3,ou=people,dc=ldaptive,dc=org")
+        .attributes(LdapAttribute.builder().name("givenName").values("ben").build())
+        .build());
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    try {
+      response.getEntry().setDn("uid=1,ou=aliens,dc=ldaptive,dc=org");
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    try {
+      response.getEntry().getAttribute("givenName").addStringValues("william");
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    try {
+      response.getReference().addUris("ldap://ds4.ldaptive.org");
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+  }
+
+
+  @Test
+  public void copy()
+  {
+    final SearchResponse response1 = SearchResponse.builder()
+      .messageID(1)
+      .controls(new SortResponseControl())
+      .entry(
+        LdapEntry.builder()
+          .messageID(1)
+          .dn("uid=1,ou=people,dc=ldaptive,dc=org")
+          .attributes(LdapAttribute.builder().name("givenName").values("bob", "robert").build())
+          .attributes(LdapAttribute.builder().name("sn").values("baker").build())
+          .build())
+      .reference(
+        SearchResultReference.builder()
+          .uris("ldap://ds1.ldaptive.org")
+          .build())
+      .build();
+    final SearchResponse copy1 = SearchResponse.copy(response1);
+    Assert.assertEquals(copy1, response1);
+    Assert.assertFalse(response1.isFrozen());
+    Assert.assertFalse(copy1.isFrozen());
+
+    final SearchResponse response2 = SearchResponse.builder()
+      .messageID(1)
+      .controls(new SortResponseControl())
+      .entry(
+        LdapEntry.builder()
+          .messageID(1)
+          .dn("uid=1,ou=people,dc=ldaptive,dc=org")
+          .attributes(LdapAttribute.builder().name("givenName").values("bob", "robert").build())
+          .attributes(LdapAttribute.builder().name("sn").values("baker").build())
+          .build())
+      .reference(
+        SearchResultReference.builder()
+          .uris("ldap://ds1.ldaptive.org")
+          .build())
+      .freeze()
+      .build();
+    final SearchResponse copy2 = SearchResponse.copy(response2);
+    Assert.assertEquals(copy2, response2);
+    Assert.assertTrue(response2.isFrozen());
+    Assert.assertFalse(copy2.isFrozen());
+  }
+
+
+  @Test
+  public void sort()
+  {
+    final SearchResponse response = SearchResponse.builder()
+      .messageID(1)
+      .controls(new SortResponseControl())
+      .entry(
+        LdapEntry.builder()
+          .messageID(1)
+          .dn("uid=bob,ou=people,dc=ldaptive,dc=org")
+          .attributes(LdapAttribute.builder().name("givenName").values("bob", "robert").build())
+          .attributes(LdapAttribute.builder().name("sn").values("baker").build())
+          .build(),
+        LdapEntry.builder()
+          .messageID(1)
+          .dn("uid=alice,ou=people,dc=ldaptive,dc=org")
+          .attributes(LdapAttribute.builder().name("givenName").values("allison", "alice").build())
+          .attributes(LdapAttribute.builder().name("sn").values("abare").build())
+          .build())
+      .reference(
+        SearchResultReference.builder()
+          .uris("ldap://ds1.ldaptive.org")
+          .build(),
+        SearchResultReference.builder()
+          .uris("ldap://directory-1.ldaptive.org")
+          .build())
+      .build();
+    final SearchResponse sort = SearchResponse.sort(response);
+    Assert.assertNotEquals(sort, response);
+    Assert.assertEquals(sort.getEntry().getDn(), "uid=alice,ou=people,dc=ldaptive,dc=org");
+    Assert.assertEquals(sort.getEntry().getAttribute("givenName").getStringValue(), "alice");
+    Assert.assertEquals(sort.getReference().getUris()[0], "ldap://directory-1.ldaptive.org");
+  }
 }

--- a/core/src/test/java/org/ldaptive/dn/DnTest.java
+++ b/core/src/test/java/org/ldaptive/dn/DnTest.java
@@ -903,4 +903,25 @@ public class DnTest
     Assert.assertTrue(nullDn.isAncestor(dn5Norm, normalizer));
     Assert.assertFalse(nullDn.isAncestor(nullDn, normalizer));
   }
+
+
+  /** Test for copy method. */
+  @Test
+  public void copy()
+  {
+    final Dn dn1 = new Dn("uid=1,ou=people,dc=ldaptive,dc=org");
+    final Dn cp1 = Dn.copy(dn1);
+    Assert.assertEquals(cp1, dn1);
+    Assert.assertFalse(dn1.isFrozen());
+    Assert.assertFalse(cp1.isFrozen());
+
+    final Dn dn2 = Dn.builder()
+      .add("uid=1,ou=people,dc=ldaptive,dc=org")
+      .freeze()
+      .build();
+    final Dn cp2 = Dn.copy(dn2);
+    Assert.assertEquals(cp2, dn2);
+    Assert.assertTrue(dn2.isFrozen());
+    Assert.assertFalse(cp2.isFrozen());
+  }
 }

--- a/core/src/test/java/org/ldaptive/dn/EqualsTest.java
+++ b/core/src/test/java/org/ldaptive/dn/EqualsTest.java
@@ -19,6 +19,7 @@ public class EqualsTest
   {
     EqualsVerifier.forClass(Dn.class)
       .suppress(Warning.STRICT_INHERITANCE)
+      .withIgnoredFields("immutable")
       .verify();
   }
 

--- a/integration/src/test/java/org/ldaptive/SearchOperationTest.java
+++ b/integration/src/test/java/org/ldaptive/SearchOperationTest.java
@@ -1813,7 +1813,7 @@ public class SearchOperationTest extends AbstractTest
     response = search.execute(request);
     Assert.assertEquals(response.getResultCode(), ResultCode.SUCCESS);
     Assert.assertTrue(response.entrySize() > 0);
-    Assert.assertTrue(response.referenceSize() > 0);
+    Assert.assertEquals(response.referenceSize(), 0);
 
     // chase search references
 


### PR DESCRIPTION
Add concept of immutableOnConstruct so that response objects have base properties that cannot be changed by handlers and other properties that can be changed. Add static copy methods so that new instances of objects can be created that are mutable.