### PR TITLE
Update search objects to support freezable.

### DIFF
--- a/core/src/main/java/org/ldaptive/AbstractMessage.java
+++ b/core/src/main/java/org/ldaptive/AbstractMessage.java
@@ -36,28 +36,28 @@ import org.ldaptive.control.ResponseControl;
 public abstract class AbstractMessage implements Message
 {
 
+  /** LDAP controls. */
+  private final List<ResponseControl> controls = new ArrayList<>();
+
   /** Protocol message ID. */
   private int messageID;
 
-  /** LDAP controls. */
-  private List<ResponseControl> controls = new ArrayList<>();
-
 
   @Override
-  public int getMessageID()
+  public final int getMessageID()
   {
     return messageID;
   }
 
 
-  public void setMessageID(final int id)
+  protected void setMessageID(final int id)
   {
     messageID = id;
   }
 
 
   @Override
-  public ResponseControl[] getControls()
+  public final ResponseControl[] getControls()
   {
     return controls != null ? controls.toArray(new ResponseControl[0]) : null;
   }
@@ -68,7 +68,7 @@ public abstract class AbstractMessage implements Message
    *
    * @param  cntrls  to add
    */
-  public void addControls(final ResponseControl... cntrls)
+  protected final void addControls(final ResponseControl... cntrls)
   {
     Collections.addAll(controls, cntrls);
   }
@@ -84,6 +84,23 @@ public abstract class AbstractMessage implements Message
   {
     setMessageID(message.getMessageID());
     addControls(message.getControls());
+  }
+
+
+  /**
+   * Returns whether the base properties of this message are equal. Those include message ID and controls.
+   *
+   * @param  message  to compare
+   *
+   * @return  whether message properties are equal
+   */
+  public final boolean equalsMessage(final Message message)
+  {
+    if (message == this) {
+      return true;
+    }
+    return LdapUtils.areEqual(getMessageID(), message.getMessageID()) &&
+      LdapUtils.areEqual(getControls(), message.getControls());
   }
 
 
@@ -301,6 +318,13 @@ public abstract class AbstractMessage implements Message
     public B controls(final ResponseControl... controls)
     {
       object.addControls(controls);
+      return self();
+    }
+
+
+    public B copy(final Message m)
+    {
+      object.copyValues(m);
       return self();
     }
 

--- a/core/src/main/java/org/ldaptive/AbstractResult.java
+++ b/core/src/main/java/org/ldaptive/AbstractResult.java
@@ -32,6 +32,9 @@ import org.ldaptive.asn1.OctetStringType;
 public abstract class AbstractResult extends AbstractMessage implements Result
 {
 
+  /** Referral URLS. */
+  private final List<String> referralURLs = new ArrayList<>();
+
   /** Result code. */
   private ResultCode resultCode;
 
@@ -41,47 +44,79 @@ public abstract class AbstractResult extends AbstractMessage implements Result
   /** Diagnostic message. */
   private String diagnosticMessage;
 
-  /** Referral URLS. */
-  private List<String> referralURLs = new ArrayList<>();
 
-
-  public ResultCode getResultCode()
+  /**
+   * Returns the result code.
+   *
+   * @return  result code
+   */
+  public final ResultCode getResultCode()
   {
     return resultCode;
   }
 
 
-  public void setResultCode(final ResultCode code)
+  /**
+   * Sets the result code.
+   *
+   * @param  code  result code
+   */
+  protected final void setResultCode(final ResultCode code)
   {
     resultCode = code;
   }
 
 
-  public String getMatchedDN()
+  /**
+   * Returns the matched DN.
+   *
+   * @return  matched DN
+   */
+  public final String getMatchedDN()
   {
     return matchedDN;
   }
 
 
-  public void setMatchedDN(final String dn)
+  /**
+   * Sets the matched DN.
+   *
+   * @param  dn  matched DN
+   */
+  protected final void setMatchedDN(final String dn)
   {
     matchedDN = dn;
   }
 
 
-  public String getDiagnosticMessage()
+  /**
+   * Returns the diagnostic message.
+   *
+   * @return  diagnostic message
+   */
+  public final String getDiagnosticMessage()
   {
     return diagnosticMessage;
   }
 
 
-  public void setDiagnosticMessage(final String message)
+  /**
+   * Sets the diagnostic message.
+   *
+   * @param  message  diagnostic message
+   */
+  protected final void setDiagnosticMessage(final String message)
   {
     diagnosticMessage = message;
   }
 
 
-  public String[] getReferralURLs()
+  /**
+   * Returns the referral URLs.
+   *
+   * @return  referral URLs
+   */
+  public final String[] getReferralURLs()
   {
     return referralURLs != null ? referralURLs.toArray(new String[0]) : null;
   }
@@ -92,7 +127,7 @@ public abstract class AbstractResult extends AbstractMessage implements Result
    *
    * @param  urls  to add
    */
-  public void addReferralURLs(final String... urls)
+  protected final void addReferralURLs(final String... urls)
   {
     Collections.addAll(referralURLs, urls);
   }
@@ -104,13 +139,36 @@ public abstract class AbstractResult extends AbstractMessage implements Result
    * @param  <T>  type of result
    * @param  result  to copy from
    */
-  protected <T extends Result> void copyValues(final T result)
+  protected final <T extends Result> void copyValues(final T result)
   {
     super.copyValues(result);
     setResultCode(result.getResultCode());
     setMatchedDN(result.getMatchedDN());
     setDiagnosticMessage(result.getDiagnosticMessage());
     addReferralURLs(result.getReferralURLs());
+  }
+
+
+  /**
+   * Returns whether the base properties of this result are equal. Those include message ID, controls, result code,
+   * matched DN, diagnostic message and referral URLs.
+   *
+   * @param  result  to compare
+   *
+   * @return  whether result properties are equal
+   */
+  public final boolean equalsResult(final Result result)
+  {
+    if (result == this) {
+      return true;
+    }
+    if (super.equalsMessage(result)) {
+      return LdapUtils.areEqual(getResultCode(), result.getResultCode()) &&
+        LdapUtils.areEqual(getMatchedDN(), result.getMatchedDN()) &&
+        LdapUtils.areEqual(getDiagnosticMessage(), result.getDiagnosticMessage()) &&
+        LdapUtils.areEqual(getReferralURLs(), result.getReferralURLs());
+    }
+    return false;
   }
 
 
@@ -276,6 +334,13 @@ public abstract class AbstractResult extends AbstractMessage implements Result
     public B referralURLs(final String... url)
     {
       object.addReferralURLs(url);
+      return self();
+    }
+
+
+    public B copy(final Result r)
+    {
+      object.copyValues(r);
       return self();
     }
   }

--- a/core/src/main/java/org/ldaptive/AddResponse.java
+++ b/core/src/main/java/org/ldaptive/AddResponse.java
@@ -14,7 +14,7 @@ import org.ldaptive.asn1.DERPath;
  *
  * @author  Middleware Services
  */
-public class AddResponse extends AbstractResult
+public final class AddResponse extends AbstractResult
 {
 
   /** BER protocol number. */
@@ -97,11 +97,11 @@ public class AddResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, AddResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, AddResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new AddResponse());
     }

--- a/core/src/main/java/org/ldaptive/BindResponse.java
+++ b/core/src/main/java/org/ldaptive/BindResponse.java
@@ -17,7 +17,7 @@ import org.ldaptive.asn1.DERPath;
  *
  * @author  Middleware Services
  */
-public class BindResponse extends AbstractResult
+public final class BindResponse extends AbstractResult
 {
 
   /** BER protocol number. */
@@ -76,7 +76,7 @@ public class BindResponse extends AbstractResult
   }
 
 
-  public void setServerSaslCreds(final byte[] creds)
+  private void setServerSaslCreds(final byte[] creds)
   {
     serverSaslCreds = creds;
   }
@@ -150,11 +150,11 @@ public class BindResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, BindResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, BindResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new BindResponse());
     }

--- a/core/src/main/java/org/ldaptive/CompareResponse.java
+++ b/core/src/main/java/org/ldaptive/CompareResponse.java
@@ -14,7 +14,7 @@ import org.ldaptive.asn1.DERPath;
  *
  * @author  Middleware Services
  */
-public class CompareResponse extends AbstractResult
+public final class CompareResponse extends AbstractResult
 {
 
   /** BER protocol number. */
@@ -119,11 +119,11 @@ public class CompareResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, CompareResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, CompareResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new CompareResponse());
     }

--- a/core/src/main/java/org/ldaptive/DeleteResponse.java
+++ b/core/src/main/java/org/ldaptive/DeleteResponse.java
@@ -14,7 +14,7 @@ import org.ldaptive.asn1.DERPath;
  *
  * @author  Middleware Services
  */
-public class DeleteResponse extends AbstractResult
+public final class DeleteResponse extends AbstractResult
 {
 
   /** BER protocol number. */
@@ -97,11 +97,11 @@ public class DeleteResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, DeleteResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, DeleteResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new DeleteResponse());
     }

--- a/core/src/main/java/org/ldaptive/ModifyDnResponse.java
+++ b/core/src/main/java/org/ldaptive/ModifyDnResponse.java
@@ -14,7 +14,7 @@ import org.ldaptive.asn1.DERPath;
  *
  * @author  Middleware Services
  */
-public class ModifyDnResponse extends AbstractResult
+public final class ModifyDnResponse extends AbstractResult
 {
 
   /** BER protocol number. */
@@ -97,11 +97,11 @@ public class ModifyDnResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, ModifyDnResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, ModifyDnResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new ModifyDnResponse());
     }

--- a/core/src/main/java/org/ldaptive/ModifyResponse.java
+++ b/core/src/main/java/org/ldaptive/ModifyResponse.java
@@ -14,7 +14,7 @@ import org.ldaptive.asn1.DERPath;
  *
  * @author  Middleware Services
  */
-public class ModifyResponse extends AbstractResult
+public final class ModifyResponse extends AbstractResult
 {
 
   /** BER protocol number. */
@@ -97,11 +97,11 @@ public class ModifyResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, ModifyResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, ModifyResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new ModifyResponse());
     }

--- a/core/src/main/java/org/ldaptive/SearchResponse.java
+++ b/core/src/main/java/org/ldaptive/SearchResponse.java
@@ -9,7 +9,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.ldaptive.asn1.DERBuffer;
 import org.ldaptive.asn1.DERParser;
 import org.ldaptive.asn1.DERPath;
@@ -25,7 +24,7 @@ import org.ldaptive.dn.Dn;
  *
  * @author  Middleware Services
  */
-public class SearchResponse extends AbstractResult
+public final class SearchResponse extends AbstractResult implements Freezable
 {
 
   /** BER protocol number. */
@@ -52,6 +51,9 @@ public class SearchResponse extends AbstractResult
   /** Search result references contained in this result. */
   private final List<SearchResultReference> resultReferences = new ArrayList<>();
 
+  /** Whether this object has been marked immutable. */
+  private volatile boolean immutable;
+
 
   /**
    * Default constructor.
@@ -77,14 +79,28 @@ public class SearchResponse extends AbstractResult
   }
 
 
-  /**
-   * Copies the values of the supplied search result done to this synthetic result.
-   *
-   * @param  result  of values to copy
-   */
-  public void initialize(final SearchResponse result)
+  @Override
+  public void freeze()
   {
-    copyValues(result);
+    immutable = true;
+    resultEntries.forEach(e -> e.freeze());
+    resultReferences.forEach(r -> r.freeze());
+  }
+
+
+  @Override
+  public boolean isFrozen()
+  {
+    return immutable;
+  }
+
+
+  @Override
+  public void assertMutable()
+  {
+    if (immutable) {
+      throw new IllegalStateException("Cannot modify immutable object");
+    }
   }
 
 
@@ -95,7 +111,7 @@ public class SearchResponse extends AbstractResult
    */
   public Collection<LdapEntry> getEntries()
   {
-    return resultEntries;
+    return Collections.unmodifiableCollection(resultEntries);
   }
 
 
@@ -149,7 +165,8 @@ public class SearchResponse extends AbstractResult
    */
   public void addEntries(final LdapEntry... entry)
   {
-    Stream.of(entry).forEach(resultEntries::add);
+    assertMutable();
+    Collections.addAll(resultEntries, entry);
   }
 
 
@@ -160,7 +177,34 @@ public class SearchResponse extends AbstractResult
    */
   public void addEntries(final Collection<LdapEntry> entries)
   {
-    entries.forEach(resultEntries::add);
+    assertMutable();
+    resultEntries.addAll(entries);
+  }
+
+
+  /**
+   * Removes an entry from this search result.
+   *
+   * @param  entry  entry to remove
+   */
+  public void removeEntries(final LdapEntry... entry)
+  {
+    assertMutable();
+    for (LdapEntry e : entry) {
+      resultEntries.remove(e);
+    }
+  }
+
+
+  /**
+   * Removes entry(s) from this search result.
+   *
+   * @param  entries  collection of entries to remove
+   */
+  public void removeEntries(final Collection<LdapEntry> entries)
+  {
+    assertMutable();
+    entries.forEach(resultEntries::remove);
   }
 
 
@@ -182,7 +226,7 @@ public class SearchResponse extends AbstractResult
    */
   public Collection<SearchResultReference> getReferences()
   {
-    return resultReferences;
+    return Collections.unmodifiableCollection(resultReferences);
   }
 
 
@@ -208,6 +252,7 @@ public class SearchResponse extends AbstractResult
    */
   public void addReferences(final SearchResultReference... reference)
   {
+    assertMutable();
     Collections.addAll(resultReferences, reference);
   }
 
@@ -219,7 +264,34 @@ public class SearchResponse extends AbstractResult
    */
   public void addReferences(final Collection<SearchResultReference> references)
   {
+    assertMutable();
     resultReferences.addAll(references);
+  }
+
+
+  /**
+   * Removes a reference from this search result.
+   *
+   * @param  reference  reference to remove
+   */
+  public void removeReferences(final SearchResultReference... reference)
+  {
+    assertMutable();
+    for (SearchResultReference r : reference) {
+      resultReferences.remove(r);
+    }
+  }
+
+
+  /**
+   * Removes references(s) from this search result.
+   *
+   * @param  references  collection of references to remove
+   */
+  public void removeReferences(final Collection<SearchResultReference> references)
+  {
+    assertMutable();
+    references.forEach(resultReferences::remove);
   }
 
 
@@ -307,25 +379,47 @@ public class SearchResponse extends AbstractResult
 
 
   /**
+   * Creates a mutable copy of the supplied search response.
+   *
+   * @param  response  to copy
+   *
+   * @return  new search response instance
+   */
+  public static SearchResponse copy(final SearchResponse response)
+  {
+    final SearchResponse copy = new SearchResponse();
+    copy.copyValues(response);
+    response.resultEntries.forEach(e -> copy.resultEntries.add(LdapEntry.copy(e)));
+    response.resultReferences.forEach(r -> copy.resultReferences.add(SearchResultReference.copy(r)));
+    return copy;
+  }
+
+
+  /**
    * Returns a new response whose entries are sorted naturally by DN. Each attribute and each attribute value are also
    * sorted. See {@link LdapEntry#sort(LdapEntry)} and {@link LdapAttribute#sort(LdapAttribute)}.
    *
-   * @param  sr  response to sort
+   * @param  result  response to sort
    *
    * @return  sorted response
    */
-  public static SearchResponse sort(final SearchResponse sr)
+  public static SearchResponse sort(final SearchResponse result)
   {
     final SearchResponse sorted = new SearchResponse();
-    sorted.copyValues(sr);
-    sorted.addEntries(sr.getEntries().stream()
+    sorted.copyValues(result);
+    final Set<LdapEntry> entries = result.getEntries().stream()
       .map(LdapEntry::sort)
       .sorted(Comparator.comparing(LdapEntry::getDn, String.CASE_INSENSITIVE_ORDER))
-      .collect(Collectors.toCollection(LinkedHashSet::new)));
-    sorted.addReferences(sr.getReferences().stream()
+      .collect(Collectors.toCollection(LinkedHashSet::new));
+    sorted.addEntries(entries);
+    final Set<SearchResultReference> references = result.getReferences().stream()
       .map(SearchResultReference::sort)
       .sorted(Comparator.comparing(SearchResultReference::hashCode))
-      .collect(Collectors.toCollection(LinkedHashSet::new)));
+      .collect(Collectors.toCollection(LinkedHashSet::new));
+    sorted.addReferences(references);
+    if (result.isFrozen()) {
+      sorted.freeze();
+    }
     return sorted;
   }
 
@@ -342,11 +436,11 @@ public class SearchResponse extends AbstractResult
 
 
   // CheckStyle:OFF
-  public static class Builder extends AbstractResult.AbstractBuilder<Builder, SearchResponse>
+  public static final class Builder extends AbstractResult.AbstractBuilder<Builder, SearchResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new SearchResponse());
     }
@@ -359,6 +453,13 @@ public class SearchResponse extends AbstractResult
     }
 
 
+    public Builder freeze()
+    {
+      object.freeze();
+      return this;
+    }
+
+
     public Builder entry(final LdapEntry... e)
     {
       object.addEntries(e);
@@ -366,9 +467,23 @@ public class SearchResponse extends AbstractResult
     }
 
 
+    public Builder entry(final Collection<LdapEntry> entries)
+    {
+      object.addEntries(entries);
+      return this;
+    }
+
+
     public Builder reference(final SearchResultReference... r)
     {
       object.addReferences(r);
+      return this;
+    }
+
+
+    public Builder reference(final Collection<SearchResultReference> references)
+    {
+      object.addReferences(references);
       return this;
     }
   }

--- a/core/src/main/java/org/ldaptive/auth/AuthenticationHandlerResponse.java
+++ b/core/src/main/java/org/ldaptive/auth/AuthenticationHandlerResponse.java
@@ -12,7 +12,7 @@ import org.ldaptive.Result;
  *
  * @author  Middleware Services
  */
-public class AuthenticationHandlerResponse extends AbstractResult
+public final class AuthenticationHandlerResponse extends AbstractResult
 {
 
   /** hash code seed. */
@@ -120,18 +120,18 @@ public class AuthenticationHandlerResponse extends AbstractResult
    *
    * @return  new builder
    */
-  protected static Builder builder()
+  static Builder builder()
   {
     return new Builder();
   }
 
 
   // CheckStyle:OFF
-  protected static class Builder extends AbstractResult.AbstractBuilder<Builder, AuthenticationHandlerResponse>
+  protected static final class Builder extends AbstractResult.AbstractBuilder<Builder, AuthenticationHandlerResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new AuthenticationHandlerResponse());
     }

--- a/core/src/main/java/org/ldaptive/auth/AuthenticationResponse.java
+++ b/core/src/main/java/org/ldaptive/auth/AuthenticationResponse.java
@@ -11,7 +11,7 @@ import org.ldaptive.LdapUtils;
  *
  * @author  Middleware Services
  */
-public class AuthenticationResponse extends AbstractResult
+public final class AuthenticationResponse extends AbstractResult
 {
 
   /** hash code seed. */
@@ -50,6 +50,7 @@ public class AuthenticationResponse extends AbstractResult
     authenticationHandlerResponse = response;
     resolvedDn = dn;
     ldapEntry = entry;
+    ldapEntry.freeze();
   }
 
 
@@ -119,6 +120,7 @@ public class AuthenticationResponse extends AbstractResult
    */
   public void setAccountState(final AccountState state)
   {
+    // account state must remain mutable for response handlers
     accountState = state;
   }
 
@@ -182,18 +184,18 @@ public class AuthenticationResponse extends AbstractResult
    *
    * @return  new builder
    */
-  protected static Builder builder()
+  static Builder builder()
   {
     return new Builder();
   }
 
 
   // CheckStyle:OFF
-  protected static class Builder extends AbstractResult.AbstractBuilder<Builder, AuthenticationResponse>
+  protected static final class Builder extends AbstractResult.AbstractBuilder<Builder, AuthenticationResponse>
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new AuthenticationResponse());
     }
@@ -208,7 +210,7 @@ public class AuthenticationResponse extends AbstractResult
 
     public Builder response(final AuthenticationHandlerResponse response)
     {
-      object.copyValues(response);
+      super.copy(response);
       object.authenticationHandlerResponse = response;
       return this;
     }

--- a/core/src/main/java/org/ldaptive/auth/NoOpEntryResolver.java
+++ b/core/src/main/java/org/ldaptive/auth/NoOpEntryResolver.java
@@ -15,7 +15,7 @@ public final class NoOpEntryResolver implements EntryResolver
   @Override
   public LdapEntry resolve(final AuthenticationCriteria criteria, final AuthenticationHandlerResponse response)
   {
-    return LdapEntry.builder().dn(criteria.getDn()).build();
+    return LdapEntry.builder().dn(criteria.getDn()).freeze().build();
   }
 
 

--- a/core/src/main/java/org/ldaptive/control/util/PagedResultsClient.java
+++ b/core/src/main/java/org/ldaptive/control/util/PagedResultsClient.java
@@ -12,8 +12,6 @@ import org.ldaptive.SearchRequest;
 import org.ldaptive.SearchResponse;
 import org.ldaptive.control.PagedResultsControl;
 import org.ldaptive.control.RequestControl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Client that simplifies using the paged results control.
@@ -22,9 +20,6 @@ import org.slf4j.LoggerFactory;
  */
 public class PagedResultsClient extends AbstractSearchOperationFactory
 {
-
-  /** Logger for this class. */
-  protected final Logger logger = LoggerFactory.getLogger(getClass());
 
   /** Results page size. */
   private final int resultSize;
@@ -226,9 +221,11 @@ public class PagedResultsClient extends AbstractSearchOperationFactory
         manager.writeCookie(cookie);
       }
     } while (cookie != null);
-    result.addEntries(combinedResults.getEntries());
-    result.addReferences(combinedResults.getReferences());
-    return result;
+    final SearchResponse finalResult = SearchResponse.copy(result);
+    finalResult.addEntries(combinedResults.getEntries());
+    finalResult.addReferences(combinedResults.getReferences());
+    finalResult.freeze();
+    return finalResult;
   }
 
 

--- a/core/src/main/java/org/ldaptive/dn/NameValue.java
+++ b/core/src/main/java/org/ldaptive/dn/NameValue.java
@@ -9,7 +9,7 @@ import org.ldaptive.LdapUtils;
  *
  * @author  Middleware Services
  */
-public class NameValue
+public final class NameValue
 {
   /** hash code seed. */
   private static final int HASH_CODE_SEED = 5011;

--- a/core/src/main/java/org/ldaptive/dn/RDn.java
+++ b/core/src/main/java/org/ldaptive/dn/RDn.java
@@ -21,7 +21,7 @@ import org.ldaptive.LdapUtils;
  *
  * @author  Middleware Services
  */
-public class RDn
+public final class RDn
 {
 
   /** hash code seed. */

--- a/core/src/main/java/org/ldaptive/extended/ExtendedResponse.java
+++ b/core/src/main/java/org/ldaptive/extended/ExtendedResponse.java
@@ -82,25 +82,25 @@ public class ExtendedResponse extends AbstractResult
   }
 
 
-  public String getResponseName()
+  public final String getResponseName()
   {
     return responseName;
   }
 
 
-  public void setResponseName(final String name)
+  protected final void setResponseName(final String name)
   {
     responseName = name;
   }
 
 
-  public byte[] getResponseValue()
+  public final byte[] getResponseValue()
   {
     return responseValue;
   }
 
 
-  public void setResponseValue(final byte[] value)
+  protected final void setResponseValue(final byte[] value)
   {
     responseValue = value;
   }

--- a/core/src/main/java/org/ldaptive/extended/IntermediateResponse.java
+++ b/core/src/main/java/org/ldaptive/extended/IntermediateResponse.java
@@ -59,25 +59,25 @@ public class IntermediateResponse extends AbstractMessage
   }
 
 
-  public String getResponseName()
+  public final String getResponseName()
   {
     return responseName;
   }
 
 
-  protected void setResponseName(final String name)
+  protected final void setResponseName(final String name)
   {
     responseName = name;
   }
 
 
-  public byte[] getResponseValue()
+  public final byte[] getResponseValue()
   {
     return responseValue;
   }
 
 
-  protected void setResponseValue(final byte[] value)
+  protected final void setResponseValue(final byte[] value)
   {
     responseValue = value;
   }

--- a/core/src/main/java/org/ldaptive/extended/NoticeOfDisconnection.java
+++ b/core/src/main/java/org/ldaptive/extended/NoticeOfDisconnection.java
@@ -18,7 +18,7 @@ import org.ldaptive.asn1.DERBuffer;
  *
  * @author  Middleware Services
  */
-public class NoticeOfDisconnection extends UnsolicitedNotification
+public final class NoticeOfDisconnection extends UnsolicitedNotification
 {
 
   /** OID of this response. */
@@ -87,11 +87,11 @@ public class NoticeOfDisconnection extends UnsolicitedNotification
 
 
   // CheckStyle:OFF
-  public static class Builder extends UnsolicitedNotification.Builder
+  public static final class Builder extends UnsolicitedNotification.Builder
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new NoticeOfDisconnection());
     }

--- a/core/src/main/java/org/ldaptive/extended/SyncInfoMessage.java
+++ b/core/src/main/java/org/ldaptive/extended/SyncInfoMessage.java
@@ -44,7 +44,7 @@ import org.ldaptive.control.ResponseControl;
  *
  * @author  Middleware Services
  */
-public class SyncInfoMessage extends IntermediateResponse
+public final class SyncInfoMessage extends IntermediateResponse
 {
 
   /** OID of this response. */
@@ -102,6 +102,9 @@ public class SyncInfoMessage extends IntermediateResponse
     SYNC_ID_SET
   }
 
+  /** entry uuids. */
+  private final Set<UUID> entryUuids = new LinkedHashSet<>();
+
   /** message type. */
   private Type messageType;
 
@@ -114,14 +117,11 @@ public class SyncInfoMessage extends IntermediateResponse
   /** refresh deletes. */
   private boolean refreshDeletes;
 
-  /** entry uuids. */
-  private Set<UUID> entryUuids = new LinkedHashSet<>();
-
 
   /**
    * Default constructor.
    */
-  protected SyncInfoMessage()
+  private SyncInfoMessage()
   {
     setResponseName(OID);
   }
@@ -143,7 +143,7 @@ public class SyncInfoMessage extends IntermediateResponse
   }
 
 
-  protected ParseHandler getResponseValueParseHandler()
+  private ParseHandler getResponseValueParseHandler()
   {
     return (parser, encoded) -> {
       final DERParser p = new DERParser();
@@ -179,7 +179,7 @@ public class SyncInfoMessage extends IntermediateResponse
    *
    * @param  type  message type
    */
-  public void setMessageType(final Type type)
+  private void setMessageType(final Type type)
   {
     messageType = type;
   }
@@ -201,7 +201,7 @@ public class SyncInfoMessage extends IntermediateResponse
    *
    * @param  value  sync request cookie
    */
-  public void setCookie(final byte[] value)
+  private void setCookie(final byte[] value)
   {
     cookie = value;
   }
@@ -223,7 +223,7 @@ public class SyncInfoMessage extends IntermediateResponse
    *
    * @param  b  refresh done
    */
-  public void setRefreshDone(final boolean b)
+  private void setRefreshDone(final boolean b)
   {
     refreshDone = b;
   }
@@ -245,7 +245,7 @@ public class SyncInfoMessage extends IntermediateResponse
    *
    * @param  b  whether to refresh deletes
    */
-  public void setRefreshDeletes(final boolean b)
+  private void setRefreshDeletes(final boolean b)
   {
     refreshDeletes = b;
   }
@@ -267,7 +267,7 @@ public class SyncInfoMessage extends IntermediateResponse
    *
    * @param  uuids  to add
    */
-  public void addEntryUuids(final UUID... uuids)
+  private void addEntryUuids(final UUID... uuids)
   {
     Collections.addAll(entryUuids, uuids);
   }
@@ -611,17 +611,17 @@ public class SyncInfoMessage extends IntermediateResponse
 
 
   // CheckStyle:OFF
-  public static class Builder extends IntermediateResponse.Builder
+  public static final class Builder extends IntermediateResponse.Builder
   {
 
 
-    protected Builder()
+    private Builder()
     {
       super(new SyncInfoMessage());
     }
 
 
-    protected Builder(final SyncInfoMessage m)
+    private Builder(final SyncInfoMessage m)
     {
       super(m);
     }
@@ -637,16 +637,32 @@ public class SyncInfoMessage extends IntermediateResponse
     @Override
     public Builder messageID(final int id)
     {
-      object.setMessageID(id);
-      return self();
+      ((SyncInfoMessage) object).setMessageID(id);
+      return this;
     }
 
 
     @Override
     public Builder controls(final ResponseControl... controls)
     {
-      object.addControls(controls);
-      return self();
+      ((SyncInfoMessage) object).addControls(controls);
+      return this;
+    }
+
+
+    @Override
+    public Builder responseName(final String name)
+    {
+      object.setResponseName(name);
+      return this;
+    }
+
+
+    @Override
+    public Builder responseValue(final byte[] value)
+    {
+      object.setResponseValue(value);
+      return this;
     }
 
 

--- a/core/src/main/java/org/ldaptive/extended/UnsolicitedNotification.java
+++ b/core/src/main/java/org/ldaptive/extended/UnsolicitedNotification.java
@@ -46,7 +46,7 @@ public class UnsolicitedNotification extends ExtendedResponse
 
 
   @Override
-  public void setMessageID(final int id)
+  protected void setMessageID(final int id)
   {
     if (id != 0) {
       throw new IllegalArgumentException("Message ID must be zero");

--- a/core/src/main/java/org/ldaptive/handler/MergeResultHandler.java
+++ b/core/src/main/java/org/ldaptive/handler/MergeResultHandler.java
@@ -40,8 +40,7 @@ public class MergeResultHandler implements SearchResultHandler
    */
   private SearchResponse merge(final SearchResponse searchResponse)
   {
-    final SearchResponse merged = new SearchResponse();
-    merged.initialize(searchResponse);
+    final SearchResponse merged = SearchResponse.builder().copy(searchResponse).build();
 
     LdapEntry mergedEntry = null;
     for (LdapEntry entry : searchResponse.getEntries()) {

--- a/core/src/main/java/org/ldaptive/referral/FollowSearchResultReferenceHandler.java
+++ b/core/src/main/java/org/ldaptive/referral/FollowSearchResultReferenceHandler.java
@@ -2,9 +2,9 @@
 package org.ldaptive.referral;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import org.ldaptive.ConnectionFactory;
+import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapURL;
 import org.ldaptive.SearchOperation;
 import org.ldaptive.SearchRequest;
@@ -124,22 +124,40 @@ public class FollowSearchResultReferenceHandler extends AbstractFollowReferralHa
     if (result.getReferences() == null || result.getReferences().isEmpty()) {
       return result;
     }
+    final SearchResponse referralResult = SearchResponse.copy(result);
+    final List<SearchResultReference> refsToAdd = new ArrayList<>();
+    final List<SearchResultReference> refsToRemove = new ArrayList<>();
     if (referralDepth <= referralLimit) {
-      final List<SearchResultReference> refCopy = new ArrayList<>(result.getReferences());
-      final Iterator<SearchResultReference> i = refCopy.iterator();
-      while (i.hasNext()) {
-        final SearchResultReference ref = i.next();
-        i.remove();
+      for (SearchResultReference ref : referralResult.getReferences()) {
+        refsToRemove.add(ref);
         final SearchResponse sr = followReferral(ref.getUris());
         if (sr != null) {
-          result.addEntries(sr.getEntries());
-          if (sr.getReferralURLs() != null && sr.getReferralURLs().length > 0) {
-            result.addReferralURLs(sr.getReferralURLs());
-          }
+          sr.getEntries().forEach(e -> {
+            final LdapEntry entry = LdapEntry.builder()
+              .copy(e)
+              .messageID(referralResult.getMessageID())
+              .build();
+            if (!referralResult.getEntries().contains(entry)) {
+              referralResult.addEntries(entry);
+            }
+          });
+          sr.getReferences().forEach(r -> {
+            final SearchResultReference reference = SearchResultReference.builder()
+              .copy(r)
+              .messageID(referralResult.getMessageID())
+              .build();
+            refsToAdd.add(reference);
+          });
+        }
+      }
+      refsToRemove.forEach(referralResult::removeReferences);
+      for (SearchResultReference reference : refsToAdd) {
+        if (!referralResult.getReferences().contains(reference)) {
+          referralResult.addReferences(reference);
         }
       }
     }
-    return result;
+    return referralResult;
   }
 
 

--- a/core/src/main/java/org/ldaptive/transport/DefaultCompareOperationHandle.java
+++ b/core/src/main/java/org/ldaptive/transport/DefaultCompareOperationHandle.java
@@ -23,7 +23,7 @@ import org.ldaptive.handler.UnsolicitedNotificationHandler;
  *
  * @author  Middleware Services
  */
-public class DefaultCompareOperationHandle
+public final class DefaultCompareOperationHandle
   extends DefaultOperationHandle<CompareRequest, CompareResponse> implements CompareOperationHandle
 {
 

--- a/core/src/main/java/org/ldaptive/transport/DefaultExtendedOperationHandle.java
+++ b/core/src/main/java/org/ldaptive/transport/DefaultExtendedOperationHandle.java
@@ -22,7 +22,7 @@ import org.ldaptive.handler.UnsolicitedNotificationHandler;
  *
  * @author  Middleware Services
  */
-public class DefaultExtendedOperationHandle
+public final class DefaultExtendedOperationHandle
   extends DefaultOperationHandle<ExtendedRequest, ExtendedResponse> implements ExtendedOperationHandle
 {
 

--- a/core/src/main/java/org/ldaptive/transport/DefaultSearchOperationHandle.java
+++ b/core/src/main/java/org/ldaptive/transport/DefaultSearchOperationHandle.java
@@ -7,6 +7,7 @@ import java.util.function.Predicate;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
 import org.ldaptive.Message;
+import org.ldaptive.ResultCode;
 import org.ldaptive.SearchOperationHandle;
 import org.ldaptive.SearchRequest;
 import org.ldaptive.SearchResponse;
@@ -29,7 +30,7 @@ import org.ldaptive.handler.UnsolicitedNotificationHandler;
  *
  * @author  Middleware Services
  */
-public class DefaultSearchOperationHandle
+public final class DefaultSearchOperationHandle
   extends DefaultOperationHandle<SearchRequest, SearchResponse> implements SearchOperationHandle
 {
 
@@ -101,29 +102,37 @@ public class DefaultSearchOperationHandle
   public SearchResponse await()
     throws LdapException
   {
-    final SearchResponse done = super.await();
-    result.initialize(done);
+    SearchResponse done = super.await();
+    done.addEntries(result.getEntries());
+    done.addReferences(result.getReferences());
     if (SORT_RESULTS) {
-      result = SearchResponse.sort(result);
+      done = SearchResponse.sort(done);
     }
-    if (onSearchResult != null) {
-      for (SearchResultHandler func : onSearchResult) {
-        try {
-          result = func.apply(result);
-        } catch (Exception ex) {
-          logger.warn("Result function {} threw an exception", func, ex);
+    try {
+      if (onSearchResult != null) {
+        for (SearchResultHandler func : onSearchResult) {
+          SearchResponse handlerResponse = null;
+          try {
+            handlerResponse = func.apply(done);
+          } catch (Exception ex) {
+            logger.warn("Result function {} threw an exception", func, ex);
+          }
+          if (handlerResponse == null) {
+            throw new IllegalStateException("Search result handler " + func + " returned null result");
+          } else if (!handlerResponse.equalsResult(done)) {
+            if (!ResultCode.REFERRAL.equals(done.getResultCode()) &&
+                !ResultCode.REFERRAL_LIMIT_EXCEEDED.equals(handlerResponse.getResultCode()))
+            {
+              throw new IllegalStateException("Cannot modify non-referral search result instance with handler " + func);
+            }
+          }
+          done = handlerResponse;
         }
       }
+    } finally {
+      done.freeze();
     }
-    return result;
-  }
-
-
-  @Override
-  public SearchResponse execute()
-    throws LdapException
-  {
-    return send().await();
+    return done;
   }
 
 
@@ -249,7 +258,14 @@ public class DefaultSearchOperationHandle
     if (onEntry != null) {
       for (LdapEntryHandler func : onEntry) {
         try {
-          e = func.apply(e);
+          final LdapEntry handlerEntry = func.apply(e);
+          if (handlerEntry == null) {
+            e = null;
+            break;
+          } else if (!handlerEntry.equalsMessage(e)) {
+            throw new IllegalStateException("Cannot modify entry instance with handler " + func);
+          }
+          e = handlerEntry;
         } catch (Exception ex) {
           logger.warn("Entry function {} in handle {} threw an exception", func, this, ex);
         }

--- a/core/src/main/java/org/ldaptive/transport/ResponseParser.java
+++ b/core/src/main/java/org/ldaptive/transport/ResponseParser.java
@@ -113,7 +113,8 @@ public class ResponseParser
       e.clear();
       final ExtendedResponse extRes = new ExtendedResponse(e);
       if (NoticeOfDisconnection.OID.equals(extRes.getResponseName())) {
-        message = new NoticeOfDisconnection();
+        e.clear();
+        message = new NoticeOfDisconnection(e);
       } else {
         message = extRes;
       }

--- a/core/src/main/java/org/ldaptive/transport/netty/NettyConnection.java
+++ b/core/src/main/java/org/ldaptive/transport/netty/NettyConnection.java
@@ -1282,7 +1282,7 @@ public final class NettyConnection extends TransportConnection
 
 
   /** Bind specific operation handle that locks other operations until the bind completes. */
-  public class BindOperationHandle extends DefaultOperationHandle<BindRequest, BindResponse>
+  public final class BindOperationHandle extends DefaultOperationHandle<BindRequest, BindResponse>
   {
 
 

--- a/core/src/test/java/org/ldaptive/EqualsTest.java
+++ b/core/src/test/java/org/ldaptive/EqualsTest.java
@@ -51,9 +51,6 @@ public class EqualsTest
           ModifyResponse.class,
         },
         new Object[] {
-          SearchResponse.class,
-        },
-        new Object[] {
           AuthenticationHandlerResponse.class,
         },
         new Object[] {
@@ -130,6 +127,18 @@ public class EqualsTest
     EqualsVerifier.forClass(SearchResultReference.class)
       .suppress(Warning.STRICT_INHERITANCE)
       .suppress(Warning.NONFINAL_FIELDS)
+      .withIgnoredFields("immutable")
+      .verify();
+  }
+
+
+  @Test
+  public void searchResponse()
+  {
+    EqualsVerifier.forClass(SearchResponse.class)
+      .suppress(Warning.STRICT_INHERITANCE)
+      .suppress(Warning.NONFINAL_FIELDS)
+      .withIgnoredFields("immutable")
       .verify();
   }
 

--- a/core/src/test/java/org/ldaptive/FreezableTest.java
+++ b/core/src/test/java/org/ldaptive/FreezableTest.java
@@ -5,14 +5,18 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import org.ldaptive.ad.handler.ObjectGuidHandler;
 import org.ldaptive.ad.handler.ObjectSidHandler;
 import org.ldaptive.ad.handler.PrimaryGroupIdHandler;
 import org.ldaptive.ad.handler.RangeEntryHandler;
+import org.ldaptive.auth.AccountState;
 import org.ldaptive.auth.AggregateAuthenticationHandler;
 import org.ldaptive.auth.AggregateAuthenticationResponseHandler;
 import org.ldaptive.auth.AggregateDnResolver;
 import org.ldaptive.auth.AggregateEntryResolver;
+import org.ldaptive.auth.AuthenticationResponse;
 import org.ldaptive.auth.Authenticator;
 import org.ldaptive.auth.AuthorizationIdentityEntryResolver;
 import org.ldaptive.auth.CompareAuthenticationHandler;
@@ -27,6 +31,7 @@ import org.ldaptive.auth.ext.FreeIPAAuthenticationResponseHandler;
 import org.ldaptive.control.SortKey;
 import org.ldaptive.control.util.PagedResultsClient;
 import org.ldaptive.control.util.VirtualListViewClient;
+import org.ldaptive.dn.Dn;
 import org.ldaptive.handler.CaseChangeEntryHandler;
 import org.ldaptive.handler.DnAttributeEntryHandler;
 import org.ldaptive.handler.MergeAttributeEntryHandler;
@@ -50,6 +55,17 @@ import org.testng.annotations.Test;
 public class FreezableTest
 {
 
+  /** Methods to ignore immutability test. */
+  private static final List<Method> IGNORE_METHODS = new ArrayList<>();
+
+  /* Initialize ignore methods. */
+  static {
+    try {
+      IGNORE_METHODS.add(AuthenticationResponse.class.getMethod("setAccountState", AccountState.class));
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   /**
    * Immutable classes.
@@ -101,6 +117,18 @@ public class FreezableTest
           SearchConnectionValidator.class,
         },
         new Object[] {
+          SearchResponse.class,
+        },
+        new Object[] {
+          LdapEntry.class,
+        },
+        new Object[] {
+          LdapAttribute.class,
+        },
+        new Object[] {
+          SearchResultReference.class,
+        },
+        new Object[] {
           IdlePruneStrategy.class,
         },
         new Object[] {
@@ -147,6 +175,9 @@ public class FreezableTest
         },
         new Object[] {
           SingleConnectionFactory.class,
+        },
+        new Object[] {
+          Dn.class,
         },
         new Object[] {
           EDirectoryAuthenticationResponseHandler.class,
@@ -225,7 +256,7 @@ public class FreezableTest
   private void invokeMethods(final Class<? extends Freezable> clazz, final Freezable i)
   {
     for (Method method : clazz.getMethods()) {
-      if (!method.isBridge()) {
+      if (!IGNORE_METHODS.contains(method) && !method.isBridge()) {
         final boolean invokeMethod =
           (method.getName().startsWith("set") || method.getName().startsWith("add")) &&
             method.getParameterTypes().length == 1;

--- a/core/src/test/java/org/ldaptive/LdapEntryTest.java
+++ b/core/src/test/java/org/ldaptive/LdapEntryTest.java
@@ -2,8 +2,10 @@
 package org.ldaptive;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.ldaptive.asn1.DefaultDERBuffer;
+import org.ldaptive.control.SortResponseControl;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -475,5 +477,76 @@ public class LdapEntryTest
     Assert.assertEquals(mods[0].getOperation(), AttributeModification.Type.REPLACE);
     Assert.assertEquals(
       mods[0].getAttribute(), LdapAttribute.builder().name("member").build());
+  }
+
+
+  @Test
+  public void immutable()
+  {
+    final LdapEntry entry = LdapEntry.builder()
+      .messageID(1)
+      .controls(new SortResponseControl())
+      .attributes(LdapAttribute.builder().name("givenName").values("bob").build())
+      .build();
+
+    entry.assertMutable();
+    entry.addAttributes(LdapAttribute.builder().name("sn").values("baker").build());
+    entry.getAttribute("givenName").addStringValues("robert");
+
+    entry.freeze();
+    try {
+      entry.addAttributes(LdapAttribute.builder().name("cn").values("robert baker").build());
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    try {
+      entry.getAttribute("givenName").addStringValues("rob");
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+  }
+
+
+  @Test
+  public void copy()
+  {
+    final LdapEntry entry1 = LdapEntry.builder()
+      .messageID(1)
+      .controls(new SortResponseControl())
+      .attributes(LdapAttribute.builder().name("givenName").values("bob").build())
+      .build();
+    final LdapEntry copy1 = LdapEntry.copy(entry1);
+    Assert.assertEquals(copy1, entry1);
+    Assert.assertFalse(entry1.isFrozen());
+    Assert.assertFalse(copy1.isFrozen());
+
+    final LdapEntry entry2 = LdapEntry.builder()
+      .messageID(2)
+      .controls(new SortResponseControl())
+      .dn("uid=bob,ou=people,dc=ldaptive,dc=org")
+      .attributes(LdapAttribute.builder().name("givenName").values("bob").build())
+      .freeze()
+      .build();
+    final LdapEntry copy2 = LdapEntry.copy(entry2);
+    Assert.assertEquals(copy2, entry2);
+    Assert.assertTrue(entry2.isFrozen());
+    Assert.assertFalse(copy2.isFrozen());
+  }
+
+
+  /** Test for sort method. */
+  @Test
+  public void sort()
+  {
+    final LdapEntry entry = new LdapEntry();
+    entry.setDn("uid=1,ou=people,dc=vt,dc=edu");
+    entry.addAttributes(new LdapAttribute("sn", "Smith", "Johnson", "Williams", "Brown", "Jones"));
+    entry.addAttributes(new LdapAttribute("giveName", "Bobby", "Bob", "Robert", "John", "James"));
+    final LdapEntry sort = LdapEntry.sort(entry);
+    Assert.assertEquals(sort, entry);
+    Assert.assertEquals(sort.getAttribute().getName(), "giveName");
+    Assert.assertEquals(sort.getAttribute().getStringValues(), List.of("Bob", "Bobby", "James", "John", "Robert"));
   }
 }

--- a/core/src/test/java/org/ldaptive/SearchResponseTest.java
+++ b/core/src/test/java/org/ldaptive/SearchResponseTest.java
@@ -679,4 +679,149 @@ public class SearchResponseTest
         .reference(SearchResultReference.builder().uris("ldap://directory-3.ldaptive.org").build())
         .build());
   }
+
+
+  @Test
+  public void immutable()
+  {
+    final SearchResponse response = SearchResponse.builder()
+      .messageID(1)
+      .controls(new SortResponseControl())
+      .entry(
+        LdapEntry.builder()
+          .messageID(1)
+          .dn("uid=1,ou=people,dc=ldaptive,dc=org")
+          .attributes(LdapAttribute.builder().name("givenName").values("bob", "robert").build())
+          .attributes(LdapAttribute.builder().name("sn").values("baker").build())
+          .build())
+      .reference(
+        SearchResultReference.builder()
+          .messageID(1)
+          .uris("ldap://ds1.ldaptive.org", "ldap://ds2.ldaptive.org")
+          .build())
+      .build();
+
+    response.assertMutable();
+    response.addEntries(
+      LdapEntry.builder()
+        .messageID(1)
+        .dn("uid=2,ou=people,dc=ldaptive,dc=org")
+        .attributes(LdapAttribute.builder().name("givenName").values("bill", "billy").build())
+        .attributes(LdapAttribute.builder().name("sn").values("thompson").build())
+        .build());
+    response.addReferences(SearchResultReference.builder().uris("ldap://ds3.ldaptive.org").build());
+    response.getEntry().setDn("uid=1,ou=robots,dc=ldaptive,dc=org");
+    response.getEntry().getAttribute("givenName").addStringValues("rob");
+
+    response.freeze();
+    try {
+      response.addEntries(LdapEntry.builder()
+        .messageID(1)
+        .dn("uid=3,ou=people,dc=ldaptive,dc=org")
+        .attributes(LdapAttribute.builder().name("givenName").values("ben").build())
+        .build());
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    try {
+      response.getEntry().setDn("uid=1,ou=aliens,dc=ldaptive,dc=org");
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    try {
+      response.getEntry().getAttribute("givenName").addStringValues("william");
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    try {
+      response.getReference().addUris("ldap://ds4.ldaptive.org");
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+  }
+
+
+  @Test
+  public void copy()
+  {
+    final SearchResponse response1 = SearchResponse.builder()
+      .messageID(1)
+      .controls(new SortResponseControl())
+      .entry(
+        LdapEntry.builder()
+          .messageID(1)
+          .dn("uid=1,ou=people,dc=ldaptive,dc=org")
+          .attributes(LdapAttribute.builder().name("givenName").values("bob", "robert").build())
+          .attributes(LdapAttribute.builder().name("sn").values("baker").build())
+          .build())
+      .reference(
+        SearchResultReference.builder()
+          .uris("ldap://ds1.ldaptive.org")
+          .build())
+      .build();
+    final SearchResponse copy1 = SearchResponse.copy(response1);
+    Assert.assertEquals(copy1, response1);
+    Assert.assertFalse(response1.isFrozen());
+    Assert.assertFalse(copy1.isFrozen());
+
+    final SearchResponse response2 = SearchResponse.builder()
+      .messageID(1)
+      .controls(new SortResponseControl())
+      .entry(
+        LdapEntry.builder()
+          .messageID(1)
+          .dn("uid=1,ou=people,dc=ldaptive,dc=org")
+          .attributes(LdapAttribute.builder().name("givenName").values("bob", "robert").build())
+          .attributes(LdapAttribute.builder().name("sn").values("baker").build())
+          .build())
+      .reference(
+        SearchResultReference.builder()
+          .uris("ldap://ds1.ldaptive.org")
+          .build())
+      .freeze()
+      .build();
+    final SearchResponse copy2 = SearchResponse.copy(response2);
+    Assert.assertEquals(copy2, response2);
+    Assert.assertTrue(response2.isFrozen());
+    Assert.assertFalse(copy2.isFrozen());
+  }
+
+
+  @Test
+  public void sort()
+  {
+    final SearchResponse response = SearchResponse.builder()
+      .messageID(1)
+      .controls(new SortResponseControl())
+      .entry(
+        LdapEntry.builder()
+          .messageID(1)
+          .dn("uid=bob,ou=people,dc=ldaptive,dc=org")
+          .attributes(LdapAttribute.builder().name("givenName").values("bob", "robert").build())
+          .attributes(LdapAttribute.builder().name("sn").values("baker").build())
+          .build(),
+        LdapEntry.builder()
+          .messageID(1)
+          .dn("uid=alice,ou=people,dc=ldaptive,dc=org")
+          .attributes(LdapAttribute.builder().name("givenName").values("allison", "alice").build())
+          .attributes(LdapAttribute.builder().name("sn").values("abare").build())
+          .build())
+      .reference(
+        SearchResultReference.builder()
+          .uris("ldap://ds1.ldaptive.org")
+          .build(),
+        SearchResultReference.builder()
+          .uris("ldap://directory-1.ldaptive.org")
+          .build())
+      .build();
+    final SearchResponse sort = SearchResponse.sort(response);
+    Assert.assertNotEquals(sort, response);
+    Assert.assertEquals(sort.getEntry().getDn(), "uid=alice,ou=people,dc=ldaptive,dc=org");
+    Assert.assertEquals(sort.getEntry().getAttribute("givenName").getStringValue(), "alice");
+    Assert.assertEquals(sort.getReference().getUris()[0], "ldap://directory-1.ldaptive.org");
+  }
 }

--- a/core/src/test/java/org/ldaptive/dn/DnTest.java
+++ b/core/src/test/java/org/ldaptive/dn/DnTest.java
@@ -903,4 +903,25 @@ public class DnTest
     Assert.assertTrue(nullDn.isAncestor(dn5Norm, normalizer));
     Assert.assertFalse(nullDn.isAncestor(nullDn, normalizer));
   }
+
+
+  /** Test for copy method. */
+  @Test
+  public void copy()
+  {
+    final Dn dn1 = new Dn("uid=1,ou=people,dc=ldaptive,dc=org");
+    final Dn cp1 = Dn.copy(dn1);
+    Assert.assertEquals(cp1, dn1);
+    Assert.assertFalse(dn1.isFrozen());
+    Assert.assertFalse(cp1.isFrozen());
+
+    final Dn dn2 = Dn.builder()
+      .add("uid=1,ou=people,dc=ldaptive,dc=org")
+      .freeze()
+      .build();
+    final Dn cp2 = Dn.copy(dn2);
+    Assert.assertEquals(cp2, dn2);
+    Assert.assertTrue(dn2.isFrozen());
+    Assert.assertFalse(cp2.isFrozen());
+  }
 }

--- a/core/src/test/java/org/ldaptive/dn/EqualsTest.java
+++ b/core/src/test/java/org/ldaptive/dn/EqualsTest.java
@@ -19,6 +19,7 @@ public class EqualsTest
   {
     EqualsVerifier.forClass(Dn.class)
       .suppress(Warning.STRICT_INHERITANCE)
+      .withIgnoredFields("immutable")
       .verify();
   }
 

--- a/core/src/test/java/org/ldaptive/extended/NoticeOfDisconnectionTest.java
+++ b/core/src/test/java/org/ldaptive/extended/NoticeOfDisconnectionTest.java
@@ -45,6 +45,7 @@ public class NoticeOfDisconnectionTest
             (byte) 0x8a, 0x16, 0x31, 0x2e, 0x33, 0x2e, 0x36, 0x2e, 0x31, 0x2e, 0x34, 0x2e, 0x31, 0x2e, 0x31, 0x34, 0x36,
             0x36, 0x2e, 0x32, 0x30, 0x30, 0x33, 0x36},
           NoticeOfDisconnection.builder()
+            .responseName(NoticeOfDisconnection.OID)
             .resultCode(ResultCode.UNAVAILABLE)
             .matchedDN("")
             .diagnosticMessage("The Directory Server is shutting down").build(),

--- a/core/src/test/java/org/ldaptive/extended/SyncInfoMessageTest.java
+++ b/core/src/test/java/org/ldaptive/extended/SyncInfoMessageTest.java
@@ -43,6 +43,7 @@ public class SyncInfoMessageTest
             0x23, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30},
           SyncInfoMessage.builder()
             .messageID(4)
+            .responseName(SyncInfoMessage.OID)
             .type(SyncInfoMessage.Type.REFRESH_DELETE)
             .cookie(
               new byte[] {
@@ -68,6 +69,7 @@ public class SyncInfoMessageTest
             0x30, 0x30, 0x30, 0x30, 0x30},
           SyncInfoMessage.builder()
             .messageID(4)
+            .responseName(SyncInfoMessage.OID)
             .type(SyncInfoMessage.Type.NEW_COOKIE)
             .cookie(
               new byte[] {
@@ -93,6 +95,7 @@ public class SyncInfoMessageTest
             0x23, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x01, 0x01, 0x00},
           SyncInfoMessage.builder()
             .messageID(4)
+            .responseName(SyncInfoMessage.OID)
             .type(SyncInfoMessage.Type.REFRESH_PRESENT)
             .refreshDone(false)
             .cookie(
@@ -123,6 +126,7 @@ public class SyncInfoMessageTest
             0x7F, 0x11, 0x6F, (byte) 0xF5, 0x6E, 0x4E, 0x59},
           SyncInfoMessage.builder()
             .messageID(4)
+            .responseName(SyncInfoMessage.OID)
             .type(SyncInfoMessage.Type.SYNC_ID_SET)
             .cookie(
               new byte[] {
@@ -151,6 +155,7 @@ public class SyncInfoMessageTest
             (byte) 0x93, 0x05, 0x09},
           SyncInfoMessage.builder()
             .messageID(4)
+            .responseName(SyncInfoMessage.OID)
             .type(SyncInfoMessage.Type.SYNC_ID_SET)
             .uuids(UUID.fromString("a1407114-b51f-103c-8093-83ef8d930509")).build(),
         },

--- a/core/src/test/java/org/ldaptive/transport/DefaultSearchOperationHandleTest.java
+++ b/core/src/test/java/org/ldaptive/transport/DefaultSearchOperationHandleTest.java
@@ -3,14 +3,17 @@ package org.ldaptive.transport;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.ldaptive.ConnectionConfig;
+import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
 import org.ldaptive.ResultCode;
@@ -20,6 +23,8 @@ import org.ldaptive.SearchResultReference;
 import org.ldaptive.ad.handler.AbstractBinaryAttributeHandler;
 import org.ldaptive.extended.IntermediateResponse;
 import org.ldaptive.handler.LdapEntryHandler;
+import org.ldaptive.handler.MergeResultHandler;
+import org.ldaptive.handler.SortResultHandler;
 import org.ldaptive.transport.mock.MockConnection;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -373,6 +378,107 @@ public class DefaultSearchOperationHandleTest
       Assert.fail("Exception was not set on the handle");
     }
     Assert.assertEquals(ResultCode.LOCAL_ERROR, ldapException.get().getResultCode());
+  }
+
+
+  /**
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport")
+  public void immutableResult()
+    throws Exception
+  {
+    final DefaultSearchOperationHandle handle = new DefaultSearchOperationHandle(
+      SearchRequest.builder().build(),
+      MockConnection.builder(
+        ConnectionConfig.builder().url("ldap://ds1.ldaptive.org").build()).abandonConsumer(req -> {}).build(),
+      Duration.ofSeconds(1));
+    handle.messageID(1);
+
+    final AtomicBoolean handlerExecuted = new AtomicBoolean();
+    handle.onSearchResult(result -> {
+      result.addReferences(SearchResultReference.builder().messageID(result.getMessageID()).build());
+      result.addEntries(LdapEntry.builder().messageID(result.getMessageID()).build());
+      Assert.assertTrue(handlerExecuted.compareAndSet(false, true));
+      return result;
+    });
+    handle.entry(LdapEntry.builder().messageID(1).build());
+    handle.result(SearchResponse.builder().messageID(1).resultCode(ResultCode.SUCCESS).build());
+    final SearchResponse result = handle.await();
+    Assert.assertTrue(handlerExecuted.get());
+    try {
+      result.addReferences(SearchResultReference.builder().messageID(result.getMessageID()).build());
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+    try {
+      result.addEntries(LdapEntry.builder().messageID(result.getMessageID()).build());
+      Assert.fail("Should have thrown exception");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getClass(), IllegalStateException.class);
+    }
+  }
+
+
+  /**
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport")
+  public void sortResultHandler()
+    throws Exception
+  {
+    final DefaultSearchOperationHandle handle = new DefaultSearchOperationHandle(
+      SearchRequest.builder().build(),
+      MockConnection.builder(
+        ConnectionConfig.builder().url("ldap://ds1.ldaptive.org").build()).abandonConsumer(req -> {}).build(),
+      Duration.ofSeconds(1));
+    handle.messageID(1);
+
+    handle.onSearchResult(new SortResultHandler());
+    handle.entry(LdapEntry.builder().messageID(1).dn("uid=xyz,ou=sort,dc=ldaptive,dc=org").build());
+    handle.entry(LdapEntry.builder().messageID(1).dn("uid=abc,ou=sort,dc=ldaptive,dc=org").build());
+    handle.result(SearchResponse.builder().messageID(1).resultCode(ResultCode.SUCCESS).build());
+    final SearchResponse result = handle.await();
+    Assert.assertNotNull(result.getEntry());
+    Assert.assertEquals(result.getEntry().getDn(), "uid=abc,ou=sort,dc=ldaptive,dc=org");
+  }
+
+
+  /**
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "transport")
+  public void mergeResultHandler()
+    throws Exception
+  {
+    final DefaultSearchOperationHandle handle = new DefaultSearchOperationHandle(
+      SearchRequest.builder().build(),
+      MockConnection.builder(
+        ConnectionConfig.builder().url("ldap://ds1.ldaptive.org").build()).abandonConsumer(req -> {}).build(),
+      Duration.ofSeconds(1));
+    handle.messageID(1);
+
+    handle.onSearchResult(new MergeResultHandler());
+    handle.entry(LdapEntry.builder()
+      .messageID(1)
+      .dn("uid=alice,ou=merge,dc=ldaptive,dc=org")
+      .attributes(
+        LdapAttribute.builder().name("givenName").values("alice").build())
+      .build());
+    handle.entry(LdapEntry.builder()
+      .messageID(1)
+      .dn("uid=bob,ou=merge,dc=ldaptive,dc=org")
+      .attributes(
+        LdapAttribute.builder().name("givenName").values("bob", "robert").build())
+      .build());
+    handle.result(SearchResponse.builder().messageID(1).resultCode(ResultCode.SUCCESS).build());
+    final SearchResponse result = handle.await();
+    Assert.assertEquals(result.entrySize(), 1);
+    Assert.assertNotNull(result.getEntry());
+    Assert.assertEquals("uid=alice,ou=merge,dc=ldaptive,dc=org", result.getEntry().getDn());
+    Assert.assertEquals(
+      List.of("alice", "bob", "robert"), result.getEntry().getAttribute("givenName").getStringValues());
   }
 
 

--- a/integration/src/test/java/org/ldaptive/SearchOperationTest.java
+++ b/integration/src/test/java/org/ldaptive/SearchOperationTest.java
@@ -1813,7 +1813,7 @@ public class SearchOperationTest extends AbstractTest
     response = search.execute(request);
     Assert.assertEquals(response.getResultCode(), ResultCode.SUCCESS);
     Assert.assertTrue(response.entrySize() > 0);
-    Assert.assertTrue(response.referenceSize() > 0);
+    Assert.assertEquals(response.referenceSize(), 0);
 
     // chase search references
 


### PR DESCRIPTION
Update objects used in the search response to implement Freezable. Update DefaultSearchOperationHandle to freeze the SearchResponse on return. Add static copy methods so that new instances of objects can be created that are mutable. Change response setter methods visibility to enforce immutability on response objects.