### PR TITLE
additional logging for eDirectory response handler

### DIFF
--- a/core/src/main/java/org/ldaptive/auth/ext/EDirectoryAuthenticationResponseHandler.java
+++ b/core/src/main/java/org/ldaptive/auth/ext/EDirectoryAuthenticationResponseHandler.java
@@ -66,13 +66,13 @@ public final class EDirectoryAuthenticationResponseHandler extends AbstractFreez
       final LdapAttribute loginRemaining = entry.getAttribute("loginGraceRemaining");
       final int loginRemainingValue = loginRemaining != null ? Integer.parseInt(loginRemaining.getStringValue()) : 0;
 
-      logger.debug("passwordExpirationTime: {}, loginGraceRemaining: {}", expTime, loginRemaining)
+      logger.debug("passwordExpirationTime: {}, loginGraceRemaining: {}", expTime, loginRemaining);
       if (expTime != null) {
         final ZonedDateTime exp = expTime.getValue(new GeneralizedTimeValueTranscoder().decoder());
-        logger.debug("Transcoded passwordExpirationTime to {}", exp)
+        logger.debug("Transcoded passwordExpirationTime to {}", exp);
         if (warningPeriod != null) {
           final ZonedDateTime warn = exp.minus(warningPeriod);
-          logger.debug("Warning period is: {}", warn)
+          logger.debug("Warning period is: {}", warn);
 
           final ZonedDateTime now = ZonedDateTime.now();
           logger.debug("Current date/time is {}", now);
@@ -85,7 +85,7 @@ public final class EDirectoryAuthenticationResponseHandler extends AbstractFreez
           response.setAccountState(new EDirectoryAccountState(exp, loginRemainingValue));
         }
       } else if (loginRemaining != null) {
-        logger.debug("passwordExpirationTime attribute has no value");
+        logger.debug("passwordExpirationTime attribute has no value; using loginGraceRemaining {}", loginRemainingValue);
         response.setAccountState(new EDirectoryAccountState(null, loginRemainingValue));
       }
     }

--- a/core/src/main/java/org/ldaptive/auth/ext/EDirectoryAuthenticationResponseHandler.java
+++ b/core/src/main/java/org/ldaptive/auth/ext/EDirectoryAuthenticationResponseHandler.java
@@ -9,6 +9,8 @@ import org.ldaptive.LdapEntry;
 import org.ldaptive.auth.AuthenticationResponse;
 import org.ldaptive.auth.AuthenticationResponseHandler;
 import org.ldaptive.transcode.GeneralizedTimeValueTranscoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Attempts to parse the authentication response and set the account state using data associated with eDirectory. The
@@ -25,6 +27,9 @@ public final class EDirectoryAuthenticationResponseHandler extends AbstractFreez
 
   /** Attributes needed to enforce password policy. */
   public static final String[] ATTRIBUTES = new String[] {"passwordExpirationTime", "loginGraceRemaining", };
+
+  /** Logger for this class. */
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
 
   /** Amount of time before expiration to produce a warning. */
   private Period warningPeriod;
@@ -49,8 +54,10 @@ public final class EDirectoryAuthenticationResponseHandler extends AbstractFreez
   public void handle(final AuthenticationResponse response)
   {
     if (response.getDiagnosticMessage() != null) {
+      logger.debug("Parsing response diagnostic message: {}", response.getDiagnosticMessage());
       final EDirectoryAccountState.Error edError = EDirectoryAccountState.Error.parse(response.getDiagnosticMessage());
       if (edError != null) {
+        logger.debug("Translated response diagnostic message to: {}", edError);
         response.setAccountState(new EDirectoryAccountState(edError));
       }
     } else if (response.isSuccess()) {
@@ -59,20 +66,30 @@ public final class EDirectoryAuthenticationResponseHandler extends AbstractFreez
       final LdapAttribute loginRemaining = entry.getAttribute("loginGraceRemaining");
       final int loginRemainingValue = loginRemaining != null ? Integer.parseInt(loginRemaining.getStringValue()) : 0;
 
+      logger.debug("passwordExpirationTime: {}, loginGraceRemaining: {}", expTime, loginRemaining)
       if (expTime != null) {
         final ZonedDateTime exp = expTime.getValue(new GeneralizedTimeValueTranscoder().decoder());
+        logger.debug("Transcoded passwordExpirationTime to {}", exp)
         if (warningPeriod != null) {
           final ZonedDateTime warn = exp.minus(warningPeriod);
-          if (ZonedDateTime.now().isAfter(warn)) {
+          logger.debug("Warning period is: {}", warn)
+
+          final ZonedDateTime now = ZonedDateTime.now();
+          logger.debug("Current date/time is {}", now);
+
+          if (now.isAfter(warn)) {
             response.setAccountState(new EDirectoryAccountState(exp, loginRemainingValue));
           }
         } else {
+          logger.debug("No warning period is defined");
           response.setAccountState(new EDirectoryAccountState(exp, loginRemainingValue));
         }
       } else if (loginRemaining != null) {
+        logger.debug("passwordExpirationTime attribute has no value");
         response.setAccountState(new EDirectoryAccountState(null, loginRemainingValue));
       }
     }
+    logger.debug("Final authentication response: {}", response);
   }
 
 


### PR DESCRIPTION
The current response handler for eDirectory has no log statements, which makes it difficult to determine how it calculates the final account state.