### PR TITLE
Add support for using SearchResultHandler with send.

### DIFF
--- a/core/src/main/java/org/ldaptive/handler/AbstractSearchResultHandler.java
+++ b/core/src/main/java/org/ldaptive/handler/AbstractSearchResultHandler.java
@@ -1,0 +1,39 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.handler;
+
+/**
+ * Base class for search result handlers.
+ *
+ * @author  Middleware Services
+ */
+public abstract class AbstractSearchResultHandler implements SearchResultHandler
+{
+
+  /** Handler usage. */
+  private final Usage usage;
+
+
+  /**
+   * Creates a new abstract search result handler.
+   *
+   * @param  u  handler usage
+   */
+  public AbstractSearchResultHandler(final Usage u)
+  {
+    usage = u;
+  }
+
+
+  @Override
+  public Usage getUsage()
+  {
+    return usage;
+  }
+
+
+  @Override
+  public String toString()
+  {
+    return getClass().getName() + "@" + hashCode() + "::" + "usage=" + usage;
+  }
+}

--- a/core/src/main/java/org/ldaptive/handler/FreezeResultHandler.java
+++ b/core/src/main/java/org/ldaptive/handler/FreezeResultHandler.java
@@ -9,11 +9,29 @@ import org.ldaptive.SearchResponse;
  *
  * @author  Middleware Services
  */
-public class FreezeResultHandler implements SearchResultHandler
+public class FreezeResultHandler extends AbstractSearchResultHandler
 {
 
   /** hash code seed. */
   private static final int HASH_CODE_SEED = 859;
+
+
+  /** Default constructor. */
+  public FreezeResultHandler()
+  {
+    this(Usage.SYNC);
+  }
+
+
+  /**
+   * Creates a new freeze result handler.
+   *
+   * @param  u  handler usage
+   */
+  public FreezeResultHandler(final Usage u)
+  {
+    super(u);
+  }
 
 
   @Override
@@ -30,20 +48,24 @@ public class FreezeResultHandler implements SearchResultHandler
     if (o == this) {
       return true;
     }
-    return o instanceof FreezeResultHandler;
+    if (o instanceof FreezeResultHandler) {
+      final FreezeResultHandler v = (FreezeResultHandler) o;
+      return LdapUtils.areEqual(getUsage(), v.getUsage());
+    }
+    return false;
   }
 
 
   @Override
   public int hashCode()
   {
-    return LdapUtils.computeHashCode(HASH_CODE_SEED);
+    return LdapUtils.computeHashCode(HASH_CODE_SEED, getUsage());
   }
 
 
   @Override
   public String toString()
   {
-    return "[" + getClass().getName() + "@" + hashCode() + "]";
+    return "[" + super.toString() + "]";
   }
 }

--- a/core/src/main/java/org/ldaptive/handler/MergeResultHandler.java
+++ b/core/src/main/java/org/ldaptive/handler/MergeResultHandler.java
@@ -12,11 +12,29 @@ import org.ldaptive.SearchResultReference;
  *
  * @author  Miguel Martinez de Espronceda
  */
-public class MergeResultHandler implements SearchResultHandler
+public class MergeResultHandler extends AbstractSearchResultHandler
 {
 
   /** hash code seed. */
   private static final int HASH_CODE_SEED = 857;
+
+
+  /** Default constructor. */
+  public MergeResultHandler()
+  {
+    this(Usage.SYNC);
+  }
+
+
+  /**
+   * Creates a new merge result handler.
+   *
+   * @param  u  handler usage
+   */
+  public MergeResultHandler(final Usage u)
+  {
+    super(u);
+  }
 
 
   @Override
@@ -82,20 +100,24 @@ public class MergeResultHandler implements SearchResultHandler
     if (o == this) {
       return true;
     }
-    return o instanceof MergeResultHandler;
+    if (o instanceof MergeResultHandler) {
+      final MergeResultHandler v = (MergeResultHandler) o;
+      return LdapUtils.areEqual(getUsage(), v.getUsage());
+    }
+    return false;
   }
 
 
   @Override
   public int hashCode()
   {
-    return LdapUtils.computeHashCode(HASH_CODE_SEED);
+    return LdapUtils.computeHashCode(HASH_CODE_SEED, getUsage());
   }
 
 
   @Override
   public String toString()
   {
-    return "[" + getClass().getName() + "@" + hashCode() + "]";
+    return "[" + super.toString() + "]";
   }
 }

--- a/core/src/main/java/org/ldaptive/handler/SearchResultHandler.java
+++ b/core/src/main/java/org/ldaptive/handler/SearchResultHandler.java
@@ -9,4 +9,27 @@ import org.ldaptive.SearchResponse;
  *
  * @author  Middleware Services
  */
-public interface SearchResultHandler extends Function<SearchResponse, SearchResponse> {}
+public interface SearchResultHandler extends Function<SearchResponse, SearchResponse>
+{
+
+
+  /** Intended usage of the handler. */
+  enum Usage {
+    /** Use this handler with {@link org.ldaptive.SearchOperation#send()}*/
+    ASYNC,
+
+    /** Use this handler with {@link org.ldaptive.SearchOperation#execute()}*/
+    SYNC
+  }
+
+
+  /**
+   * Returns the usage for this handler.
+   *
+   * @return  handler usage
+   */
+  default Usage getUsage()
+  {
+    return Usage.SYNC;
+  }
+}

--- a/core/src/main/java/org/ldaptive/handler/SortResultHandler.java
+++ b/core/src/main/java/org/ldaptive/handler/SortResultHandler.java
@@ -9,11 +9,29 @@ import org.ldaptive.SearchResponse;
  *
  * @author  Middleware Services
  */
-public class SortResultHandler implements SearchResultHandler
+public class SortResultHandler extends AbstractSearchResultHandler
 {
 
   /** hash code seed. */
   private static final int HASH_CODE_SEED = 853;
+
+
+  /** Default constructor. */
+  public SortResultHandler()
+  {
+    this(Usage.SYNC);
+  }
+
+
+  /**
+   * Creates a new sort result handler.
+   *
+   * @param  u  handler usage
+   */
+  public SortResultHandler(final Usage u)
+  {
+    super(u);
+  }
 
 
   @Override
@@ -29,20 +47,24 @@ public class SortResultHandler implements SearchResultHandler
     if (o == this) {
       return true;
     }
-    return o instanceof SortResultHandler;
+    if (o instanceof SortResultHandler) {
+      final SortResultHandler v = (SortResultHandler) o;
+      return LdapUtils.areEqual(getUsage(), v.getUsage());
+    }
+    return false;
   }
 
 
   @Override
   public int hashCode()
   {
-    return LdapUtils.computeHashCode(HASH_CODE_SEED);
+    return LdapUtils.computeHashCode(HASH_CODE_SEED, getUsage());
   }
 
 
   @Override
   public String toString()
   {
-    return "[" + getClass().getName() + "@" + hashCode() + "]";
+    return "[" + super.toString() + "]";
   }
 }


### PR DESCRIPTION
Add enum to define whether a SearchResultHandler is being used with the send or execute method. Update DefaultSearchOperationHandle to process handlers configured for send.