### PR TITLE
Improve flexibility of prune strategy.

### DIFF
--- a/core/src/main/java/org/ldaptive/AbstractPassiveConnectionStrategy.java
+++ b/core/src/main/java/org/ldaptive/AbstractPassiveConnectionStrategy.java
@@ -1,0 +1,39 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive;
+
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Base class for connection strategies that implement an active/passive format for URLs. This format indicates that the
+ * first URL in the list is the most desirable and should be attempted first. Followed by URLs that are less desirable.
+ *
+ * @author  Middleware Services
+ */
+public abstract class AbstractPassiveConnectionStrategy extends AbstractConnectionStrategy
+{
+
+
+  @Override
+  public void populate(final String urls, final LdapURLSet urlSet)
+  {
+    if (urls == null || urls.isEmpty()) {
+      throw new IllegalArgumentException("urls cannot be empty or null");
+    }
+    if (urls.contains(" ")) {
+      final String[] urlArray = urls.split(" ");
+      urlSet.populate(IntStream.range(0, urlArray.length)
+        .mapToObj(i -> {
+          final LdapURL url = new LdapURL(urlArray[i]);
+          url.setRetryMetadata(new LdapURLRetryMetadata(this));
+          url.setPriority(i);
+          return url;
+        }).collect(Collectors.toList()));
+    } else {
+      final LdapURL url = new LdapURL(urls);
+      url.setRetryMetadata(new LdapURLRetryMetadata(this));
+      urlSet.populate(Collections.singletonList(url));
+    }
+  }
+}

--- a/core/src/main/java/org/ldaptive/ActivePassiveConnectionStrategy.java
+++ b/core/src/main/java/org/ldaptive/ActivePassiveConnectionStrategy.java
@@ -11,7 +11,7 @@ import java.util.function.Function;
  *
  * @author  Middleware Services
  */
-public class ActivePassiveConnectionStrategy extends AbstractConnectionStrategy
+public class ActivePassiveConnectionStrategy extends AbstractPassiveConnectionStrategy
 {
 
   /** Custom iterator function. */

--- a/core/src/main/java/org/ldaptive/DnsResolverConnectionStrategy.java
+++ b/core/src/main/java/org/ldaptive/DnsResolverConnectionStrategy.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
  *
  * @author  Middleware Services
  */
-public class DnsResolverConnectionStrategy extends AbstractConnectionStrategy
+public class DnsResolverConnectionStrategy extends AbstractPassiveConnectionStrategy
 {
 
   /** Default time to live for DNS results. */

--- a/core/src/main/java/org/ldaptive/DnsSrvConnectionStrategy.java
+++ b/core/src/main/java/org/ldaptive/DnsSrvConnectionStrategy.java
@@ -117,6 +117,7 @@ public class DnsSrvConnectionStrategy extends AbstractConnectionStrategy
       .map(srv -> {
         final LdapURL url = srv.getLdapURL();
         url.setRetryMetadata(new LdapURLRetryMetadata(this));
+        url.setPriority(srv.getPriority());
         return url;
       })
       .collect(Collectors.toList());

--- a/core/src/main/java/org/ldaptive/LdapURL.java
+++ b/core/src/main/java/org/ldaptive/LdapURL.java
@@ -33,6 +33,8 @@ public final class LdapURL
   /** IP address resolved for this URL. */
   private InetAddress inetAddress;
 
+  /** Priority of this URL. Lower numbers indicate higher priority. */
+  private long priority;
 
   /** Private constructor. */
   private LdapURL() {}
@@ -229,6 +231,31 @@ public final class LdapURL
   void setInetAddress(final InetAddress address)
   {
     inetAddress = address;
+  }
+
+
+  /**
+   * Returns the priority of this URL. Lower numbers indicate a higher priority.
+   *
+   * @return  priority for this URL.
+   */
+  public long getPriority()
+  {
+    return priority;
+  }
+
+
+  /**
+   * Sets the priority of this URL.
+   *
+   * @param  p  priority for this URL
+   */
+  void setPriority(final long p)
+  {
+    if (p < 0) {
+      throw new IllegalArgumentException("Priority cannot be negative");
+    }
+    priority = p;
   }
 
 

--- a/core/src/main/java/org/ldaptive/LdapURLSet.java
+++ b/core/src/main/java/org/ldaptive/LdapURLSet.java
@@ -33,6 +33,11 @@ public final class LdapURLSet
   }
 
 
+  /**
+   * Returns the URLs in this set with active URLs ordered before inactive.
+   *
+   * @return  URLs with active ordered before inactive
+   */
   public List<LdapURL> getUrls()
   {
     final List<LdapURL> l = new ArrayList<>(getActiveUrls());

--- a/core/src/main/java/org/ldaptive/pool/AbstractPruneStrategy.java
+++ b/core/src/main/java/org/ldaptive/pool/AbstractPruneStrategy.java
@@ -14,9 +14,6 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractPruneStrategy extends AbstractFreezable implements PruneStrategy
 {
 
-  /** Default prune period in seconds. Value is 5 minutes. */
-  protected static final Duration DEFAULT_PRUNE_PERIOD = Duration.ofMinutes(5);
-
   /** Logger for this class. */
   protected final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/core/src/main/java/org/ldaptive/pool/AgePruneStrategy.java
+++ b/core/src/main/java/org/ldaptive/pool/AgePruneStrategy.java
@@ -1,0 +1,234 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.pool;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Removes connections from the pool based on how long they have existed. By default, this implementation executes every
+ * 30 minutes and prunes connections that have existed for more than 1 hour. Setting an age time of zero means that no
+ * connections will be pruned by this strategy. This strategy will prune available connections below the minimum pool
+ * size. This strategy will also only prune connections that have a higher priority if {@link #prunePriority} is set.
+ * The higher the priority the quicker the connection will be removed.
+ *
+ * @author  Middleware Services
+ */
+public class AgePruneStrategy extends AbstractPruneStrategy
+{
+
+  /** Default age time. Value is 1 hour. */
+  private static final Duration DEFAULT_AGE_TIME = Duration.ofHours(1);
+
+  /** Age time. */
+  private Duration ageTime;
+
+  /**
+   * Threshold at which to prune connections based on their priority. Connections with a priority &gt;= to this value
+   * will be pruned.
+   */
+  private long prunePriority = -1L;
+
+
+  /** Creates a new age prune strategy. */
+  public AgePruneStrategy()
+  {
+    this(DEFAULT_AGE_TIME);
+  }
+
+
+  /**
+   * Creates a new age prune strategy. Sets the prune period to half of the supplied age time.
+   *
+   * @param  age  time at which a connection should be pruned
+   */
+  public AgePruneStrategy(final Duration age)
+  {
+    this(age.dividedBy(2), age);
+  }
+
+
+  /**
+   * Creates a new age prune strategy.
+   *
+   * @param  period  to execute the prune task
+   * @param  age  time at which a connection should be pruned
+   */
+  public AgePruneStrategy(final Duration period, final Duration age)
+  {
+    setPrunePeriod(period);
+    setAgeTime(age);
+  }
+
+
+  @Override
+  public List<Predicate<PoolState>> apply(final PooledConnectionProxy conn)
+  {
+    final List<Predicate<PoolState>> predicates;
+    if (Duration.ZERO.equals(ageTime)) {
+      predicates = List.of(poolState -> false);
+    } else {
+      final Instant timeCreated = conn.getCreatedTime();
+      logger.trace("evaluating created time {} for connection {}", timeCreated, conn);
+      if (prunePriority >= 0) {
+        final long priority = conn.getConnection().getLdapURL().getPriority();
+        if (prunePriority >= priority) {
+          predicates = List.of(
+            poolState -> timeCreated == null ||
+              timeCreated.plus(ageTime.dividedBy(priority + 1)).isBefore(Instant.now()));
+        } else {
+          predicates = List.of(poolState -> false);
+        }
+      } else {
+        predicates = List.of(poolState -> timeCreated == null || timeCreated.plus(ageTime).isBefore(Instant.now()));
+      }
+    }
+    return predicates;
+  }
+
+
+  @Override
+  public int getStatisticsSize()
+  {
+    return 0;
+  }
+
+
+  @Override
+  public int getPredicateSize()
+  {
+    return 1;
+  }
+
+
+  /**
+   * Returns the age time.
+   *
+   * @return  age time
+   */
+  public Duration getAgeTime()
+  {
+    return ageTime;
+  }
+
+
+  /**
+   * Sets the age time.
+   *
+   * @param  time  since a connection has been created and should be pruned
+   */
+  public void setAgeTime(final Duration time)
+  {
+    assertMutable();
+    if (time == null || time.isNegative()) {
+      throw new IllegalArgumentException("Age time cannot be null or negative");
+    }
+    ageTime = time;
+  }
+
+
+  /**
+   * Returns the prune priority.
+   *
+   * @return  priority value at which to prune
+   */
+  public long getPrunePriority()
+  {
+    return prunePriority;
+  }
+
+
+  /**
+   * Sets the prune priority.
+   *
+   * @param  l  priority value at which to prune
+   */
+  public void setPrunePriority(final long l)
+  {
+    assertMutable();
+    if (l < -1) {
+      throw new IllegalArgumentException("Prune by priority must be greater than or equal to -1");
+    }
+    prunePriority = l;
+  }
+
+
+  @Override
+  public String toString()
+  {
+    return "[" +
+      getClass().getName() + "@" + hashCode() + "::" +
+      "prunePeriod=" + getPrunePeriod() + ", " +
+      "ageTime=" + ageTime + ", " +
+      "pruneByPriority=" + prunePriority + "]";
+  }
+
+
+  /**
+   * Creates a builder for this class.
+   *
+   * @return  new builder
+   */
+  public static Builder builder()
+  {
+    return new Builder();
+  }
+
+
+  /** Age prune strategy builder. */
+  public static class Builder extends
+    AbstractPruneStrategy.AbstractBuilder<Builder, AgePruneStrategy>
+  {
+
+
+    /**
+     * Creates a new builder.
+     */
+    protected Builder()
+    {
+      super(new AgePruneStrategy());
+    }
+
+
+    protected Builder(final AgePruneStrategy strategy)
+    {
+      super(strategy);
+    }
+
+
+    @Override
+    protected Builder self()
+    {
+      return this;
+    }
+
+
+    /**
+     * Sets the prune age time.
+     *
+     * @param  time  to set
+     *
+     * @return  this builder
+     */
+    public Builder age(final Duration time)
+    {
+      object.setAgeTime(time);
+      return self();
+    }
+
+
+    /**
+     * Sets the prune priority.
+     *
+     * @param  l  prune priority
+     *
+     * @return  this builder
+     */
+    public Builder priority(final long l)
+    {
+      object.setPrunePriority(l);
+      return self();
+    }
+  }
+}

--- a/core/src/main/java/org/ldaptive/pool/DefaultPoolState.java
+++ b/core/src/main/java/org/ldaptive/pool/DefaultPoolState.java
@@ -1,0 +1,63 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.pool;
+
+/**
+ * Default implementation of {@link PoolState}.
+ *
+ * @author  Middleware Services
+ */
+final class DefaultPoolState implements PoolState
+{
+
+  /** Connection pool. */
+  private final ConnectionPool connectionPool;
+
+  /** Minimum pool size. */
+  private final int minPoolSize;
+
+  /** Maximum pool size. */
+  private final int maxPoolSize;
+
+
+  /**
+   * Creates a new prune pool state.
+   *
+   * @param  pool  connection pool
+   * @param  min  the minimum pool size
+   * @param  max  the maximum pool size
+   */
+  DefaultPoolState(final ConnectionPool pool, final int min, final int max)
+  {
+    connectionPool = pool;
+    minPoolSize = min;
+    maxPoolSize = max;
+  }
+
+
+  @Override
+  public int getMinPoolSize()
+  {
+    return minPoolSize;
+  }
+
+
+  @Override
+  public int getMaxPoolSize()
+  {
+    return maxPoolSize;
+  }
+
+
+  @Override
+  public int getAvailableCount()
+  {
+    return connectionPool.availableCount();
+  }
+
+
+  @Override
+  public int getActiveCount()
+  {
+    return connectionPool.activeCount();
+  }
+}

--- a/core/src/main/java/org/ldaptive/pool/IdlePruneStrategy.java
+++ b/core/src/main/java/org/ldaptive/pool/IdlePruneStrategy.java
@@ -3,18 +3,21 @@ package org.ldaptive.pool;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * Removes connections from the pool based on how long they have been idle in the available queue. By default, this
- * implementation executes every 5 minutes and prunes connections that have been idle for more than 10 minutes.
+ * implementation executes every 5 minutes and prunes connections that have been idle for more than 10 minutes. This
+ * strategy will not prune available connections below the minimum pool size unless an age time is configured.
+ * Connections will be pruned by age before they are pruned by idle time.
  *
  * @author  Middleware Services
  */
-public class IdlePruneStrategy extends AbstractPruneStrategy
+public class IdlePruneStrategy extends AgePruneStrategy
 {
-
-  /** Default number of statistics to store. Value is {@value}. */
-  private static final int DEFAULT_STATISTICS_SIZE = 1;
 
   /** Default idle time. Value is 10 minutes. */
   private static final Duration DEFAULT_IDLE_TIME = Duration.ofMinutes(10);
@@ -26,7 +29,7 @@ public class IdlePruneStrategy extends AbstractPruneStrategy
   /** Creates a new idle prune strategy. */
   public IdlePruneStrategy()
   {
-    this(DEFAULT_PRUNE_PERIOD, DEFAULT_IDLE_TIME);
+    this(DEFAULT_IDLE_TIME);
   }
 
 
@@ -37,8 +40,7 @@ public class IdlePruneStrategy extends AbstractPruneStrategy
    */
   public IdlePruneStrategy(final Duration idle)
   {
-    setPrunePeriod(idle.dividedBy(2));
-    setIdleTime(idle);
+    this(idle.dividedBy(2), idle);
   }
 
 
@@ -50,24 +52,55 @@ public class IdlePruneStrategy extends AbstractPruneStrategy
    */
   public IdlePruneStrategy(final Duration period, final Duration idle)
   {
+    this(period, idle, Duration.ZERO);
+  }
+
+
+  /**
+   * Creates a new idle prune strategy.
+   *
+   * @param  period  to execute the prune task
+   * @param  idle  time at which a connection should be pruned
+   * @param  age  time at which a connection should be pruned
+   */
+  public IdlePruneStrategy(final Duration period, final Duration idle, final Duration age)
+  {
     setPrunePeriod(period);
     setIdleTime(idle);
+    setAgeTime(age);
   }
 
 
   @Override
-  public Boolean apply(final PooledConnectionProxy conn)
+  public List<Predicate<PoolState>> apply(final PooledConnectionProxy conn)
   {
     final Instant timeAvailable = conn.getPooledConnectionStatistics().getLastAvailableStat();
-    logger.trace("evaluating timestamp {} for connection {}", timeAvailable, conn);
-    return timeAvailable == null || timeAvailable.plus(idleTime).isBefore(Instant.now());
+    logger.trace("evaluating time available {} for connection {}", timeAvailable, conn);
+
+    final List<Predicate<PoolState>> predicates = new ArrayList<>(super.apply(conn));
+    predicates.add(poolState -> {
+      final int numConnAboveMin = poolState.getTotalCount() - poolState.getMinPoolSize();
+      final int numConnToPrune = Math.min(poolState.getAvailableCount(), numConnAboveMin);
+      if (numConnToPrune > 0) {
+        return timeAvailable == null || timeAvailable.plus(idleTime).isBefore(Instant.now());
+      }
+      return false;
+    });
+    return Collections.unmodifiableList(predicates);
   }
 
 
   @Override
   public int getStatisticsSize()
   {
-    return DEFAULT_STATISTICS_SIZE;
+    return 1;
+  }
+
+
+  @Override
+  public int getPredicateSize()
+  {
+    return 2;
   }
 
 
@@ -103,6 +136,7 @@ public class IdlePruneStrategy extends AbstractPruneStrategy
     return "[" +
       getClass().getName() + "@" + hashCode() + "::" +
       "prunePeriod=" + getPrunePeriod() + ", " +
+      "ageTime=" + getAgeTime() + ", " +
       "idleTime=" + idleTime + "]";
   }
 
@@ -112,15 +146,14 @@ public class IdlePruneStrategy extends AbstractPruneStrategy
    *
    * @return  new builder
    */
-  public static IdlePruneStrategy.Builder builder()
+  public static Builder builder()
   {
-    return new IdlePruneStrategy.Builder();
+    return new Builder();
   }
 
 
   /** Idle prune strategy builder. */
-  public static class Builder extends
-    AbstractPruneStrategy.AbstractBuilder<IdlePruneStrategy.Builder, IdlePruneStrategy>
+  public static class Builder extends AgePruneStrategy.Builder
   {
 
 
@@ -134,7 +167,7 @@ public class IdlePruneStrategy extends AbstractPruneStrategy
 
 
     @Override
-    protected IdlePruneStrategy.Builder self()
+    protected Builder self()
     {
       return this;
     }
@@ -147,9 +180,25 @@ public class IdlePruneStrategy extends AbstractPruneStrategy
      *
      * @return  this builder
      */
-    public IdlePruneStrategy.Builder idle(final Duration time)
+    public Builder idle(final Duration time)
     {
-      object.setIdleTime(time);
+      ((IdlePruneStrategy) object).setIdleTime(time);
+      return self();
+    }
+
+
+    @Override
+    public Builder age(final Duration time)
+    {
+      object.setAgeTime(time);
+      return self();
+    }
+
+
+    @Override
+    public Builder priority(final long l)
+    {
+      object.setPrunePriority(l);
       return self();
     }
   }

--- a/core/src/main/java/org/ldaptive/pool/PoolState.java
+++ b/core/src/main/java/org/ldaptive/pool/PoolState.java
@@ -1,0 +1,54 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.pool;
+
+/**
+ * Interface that defines the pool properties that can be used by a {@link PruneStrategy} to prune connections.
+ *
+ * @author  Middleware Services
+ */
+public interface PoolState
+{
+
+
+  /**
+   * Returns the minimum size of the connection pool.
+   *
+   * @return  minimum size of the connection pool
+   */
+  int getMinPoolSize();
+
+
+  /**
+   * Returns the maximum size of the connection pool.
+   *
+   * @return  maximum size of the connection pool
+   */
+  int getMaxPoolSize();
+
+
+  /**
+   * Returns the number of connection in the available queue.
+   *
+   * @return  number of connection in the available queue.
+   */
+  int getAvailableCount();
+
+
+  /**
+   * Returns the number of connections in the active queue
+   *
+   * @return  number of connections in the active queue
+   */
+  int getActiveCount();
+
+
+  /**
+   * Returns the number of connections in both the available and active queues.
+   *
+   * @return  number of connections in both the available and active queues
+   */
+  default int getTotalCount()
+  {
+    return getAvailableCount() + getActiveCount();
+  }
+}

--- a/core/src/main/java/org/ldaptive/pool/PooledConnectionProxy.java
+++ b/core/src/main/java/org/ldaptive/pool/PooledConnectionProxy.java
@@ -2,6 +2,7 @@
 package org.ldaptive.pool;
 
 import java.lang.reflect.InvocationHandler;
+import java.time.Instant;
 import org.ldaptive.Connection;
 
 /**
@@ -11,14 +12,6 @@ import org.ldaptive.Connection;
  */
 public interface PooledConnectionProxy extends InvocationHandler
 {
-
-
-  /**
-   * Returns the connection pool that this proxy is participating in.
-   *
-   * @return  connection pool
-   */
-  ConnectionPool getConnectionPool();
 
 
   /**
@@ -34,7 +27,7 @@ public interface PooledConnectionProxy extends InvocationHandler
    *
    * @return  creation timestamp in milliseconds
    */
-  long getCreatedTime();
+  Instant getCreatedTime();
 
 
   /**

--- a/core/src/main/java/org/ldaptive/pool/PruneStrategy.java
+++ b/core/src/main/java/org/ldaptive/pool/PruneStrategy.java
@@ -2,14 +2,20 @@
 package org.ldaptive.pool;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
- * Provides an interface for pruning connections from the pool.
+ * Provides an interface for pruning connections from the pool. The list of predicates provided by the strategy are used
+ * against the entire pool in order. So that connections pruned by the first predicate are no longer available when the
+ * second predicate is used. The input to the predicate is the connection pool and its minimum pool size. In this
+ * fashion, a prune strategy can order any number of predicates, each of which can inspect the pool and make a
+ * determination which to prune a connection.
  *
  * @author  Middleware Services
  */
-public interface PruneStrategy extends Function<PooledConnectionProxy, Boolean>
+public interface PruneStrategy extends Function<PooledConnectionProxy, List<Predicate<PoolState>>>
 {
 
 
@@ -19,6 +25,15 @@ public interface PruneStrategy extends Function<PooledConnectionProxy, Boolean>
    * @return  number of statistics to store
    */
   int getStatisticsSize();
+
+
+  /**
+   * Returns the number of predicates this prune strategy uses. Must match the size of the list returned by
+   * {@link #apply(Object)}.
+   *
+   * @return  number of predicates this prune strategy uses
+   */
+  int getPredicateSize();
 
 
   /**

--- a/core/src/test/java/org/ldaptive/EqualsTest.java
+++ b/core/src/test/java/org/ldaptive/EqualsTest.java
@@ -157,7 +157,7 @@ public class EqualsTest
     EqualsVerifier.forClass(LdapURL.class)
       .suppress(Warning.STRICT_INHERITANCE)
       .suppress(Warning.NONFINAL_FIELDS)
-      .withIgnoredFields("retryMetadata", "active")
+      .withIgnoredFields("retryMetadata", "active", "priority")
       .verify();
   }
 

--- a/core/src/test/java/org/ldaptive/pool/AgePruneStrategyTest.java
+++ b/core/src/test/java/org/ldaptive/pool/AgePruneStrategyTest.java
@@ -1,0 +1,158 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.pool;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.ldaptive.ConnectionConfig;
+import org.ldaptive.transport.mock.MockConnection;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Unit test for {@link AgePruneStrategy}.
+ *
+ * @author  Middleware Services
+ */
+public class AgePruneStrategyTest
+{
+
+  /** Mock connection for testing. */
+  private final MockConnection activeConn =
+    MockConnection.builder(ConnectionConfig.builder().url("ldap://ds1.ldaptive.org ldap://ds2.ldaptive.org").build())
+      .openPredicate(url -> true)
+      .build();
+
+  /** Mock connection for testing. */
+  private final MockConnection passiveConn =
+    MockConnection.builder(ConnectionConfig.builder().url("ldap://ds1.ldaptive.org ldap://ds2.ldaptive.org").build())
+      .openPredicate(url -> !url.getHostname().startsWith("ds1"))
+      .build();
+
+
+  /**
+   * Prune strategy test data.
+   *
+   * @return  test data
+   *
+   * @throws  Exception  if test data cannot be generated
+   */
+  @DataProvider(name = "conns")
+  @SuppressWarnings("unchecked")
+  public Object[][] createConnections()
+    throws Exception
+  {
+    // initialize the LDAP URL in the connections
+    activeConn.open();
+    passiveConn.open();
+
+    final MockConnectionPool<?, ?> idlePool = new MockConnectionPool<>(
+      List.of(activeConn, activeConn, activeConn), List.of());
+
+    return
+      new Object[][] {
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            passiveConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofDays(6))),
+          AgePruneStrategy.builder().priority(1).age(Duration.ZERO).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            passiveConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofDays(6))),
+          AgePruneStrategy.builder().age(Duration.ZERO).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofDays(6))),
+          AgePruneStrategy.builder().age(Duration.ZERO).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofDays(6))),
+          AgePruneStrategy.builder().age(Duration.ZERO).priority(1).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            passiveConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(6))),
+          AgePruneStrategy.builder().priority(1).age(Duration.ofMinutes(5)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            passiveConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(6))),
+          AgePruneStrategy.builder().age(Duration.ofMinutes(5)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(6))),
+          AgePruneStrategy.builder().age(Duration.ofMinutes(5)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(6))),
+          AgePruneStrategy.builder().age(Duration.ofMinutes(5)).priority(1).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            passiveConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(3))),
+          AgePruneStrategy.builder().priority(1).age(Duration.ofMinutes(5)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            passiveConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(3))),
+          AgePruneStrategy.builder().age(Duration.ofMinutes(5)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(3))),
+          AgePruneStrategy.builder().age(Duration.ofMinutes(5)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(3))),
+          AgePruneStrategy.builder().age(Duration.ofMinutes(5)).priority(1).build(),
+          false,
+        },
+      };
+  }
+
+
+  /**
+   * Unit test for {@link AgePruneStrategy#apply(PooledConnectionProxy)}.
+   *
+   * @param  pool  to prune
+   * @param  conn  to apply to strategy
+   * @param  strategy  prune strategy
+   * @param  result  expected result of the strategy
+   */
+  @Test(groups = "conn", dataProvider = "conns")
+  public void apply(
+    final ConnectionPool pool, final PooledConnectionProxy conn, final AgePruneStrategy strategy, final boolean result)
+  {
+    assertThat(strategy.apply(conn).stream().anyMatch(p -> p.test(new DefaultPoolState(pool, 3, 10))))
+      .isEqualTo(result);
+  }
+}

--- a/core/src/test/java/org/ldaptive/pool/IdlePruneStrategyTest.java
+++ b/core/src/test/java/org/ldaptive/pool/IdlePruneStrategyTest.java
@@ -1,10 +1,11 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.ldaptive.pool;
 
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.Instant;
-import org.ldaptive.Connection;
+import java.util.List;
+import org.ldaptive.ConnectionConfig;
+import org.ldaptive.transport.mock.MockConnection;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.assertj.core.api.Assertions.*;
@@ -17,106 +18,550 @@ import static org.assertj.core.api.Assertions.*;
 public class IdlePruneStrategyTest
 {
 
+  /** Mock connection for testing. */
+  private final MockConnection activeConn =
+    MockConnection.builder(ConnectionConfig.builder().url("ldap://ds1.ldaptive.org ldap://ds2.ldaptive.org").build())
+      .openPredicate(url -> true)
+      .build();
+
+  /** Mock connection for testing. */
+  private final MockConnection passiveConn =
+    MockConnection.builder(ConnectionConfig.builder().url("ldap://ds1.ldaptive.org ldap://ds2.ldaptive.org").build())
+      .openPredicate(url -> !url.getHostname().startsWith("ds1"))
+      .build();
+
 
   /**
    * Prune strategy test data.
    *
    * @return  test data
+   *
+   * @throws  Exception  if test data cannot be generated
    */
+  // CheckStyle:MethodLength OFF
   @DataProvider(name = "conns")
+  @SuppressWarnings("unchecked")
   public Object[][] createConnections()
+    throws Exception
   {
+    // initialize the LDAP URL in the connections
+    activeConn.open();
+    passiveConn.open();
+
+    // create connection pools for testing
+    final MockConnectionPool<?, ?> idlePool = new MockConnectionPool<>(
+      List.of(activeConn, activeConn, activeConn), List.of());
+
+    final MockConnectionPool<?, ?> idlePrunePool = new MockConnectionPool<>(
+      List.of(activeConn, activeConn, activeConn, activeConn, activeConn, activeConn), List.of());
+
+    final MockConnectionPool<?, ?> activePool = new MockConnectionPool<>(
+      List.of(), List.of(activeConn, activeConn, activeConn));
+
+    final MockConnectionPool<?, ?> activePrunePool = new MockConnectionPool<>(
+      List.of(activeConn, activeConn, activeConn, activeConn, activeConn, activeConn),
+      List.of(activeConn, activeConn, activeConn));
+
+    // create various statistics for testing
     final PooledConnectionStatistics noLastAvailableStat = new PooledConnectionStatistics(1);
     final PooledConnectionStatistics notIdleLongEnough = new PooledConnectionStatistics(1);
     notIdleLongEnough.addAvailableStat(Instant.now().minusSeconds(10));
     final PooledConnectionStatistics idleTooLong = new PooledConnectionStatistics(1);
     idleTooLong.addAvailableStat(Instant.now().minusSeconds(120));
+
     return
       new Object[][] {
+        // idlePool should only exercise age pruning and passive connections
         new Object[] {
-          new TestPooledConnectionProxy(noLastAvailableStat),
-          Duration.ofMinutes(1),
-          true,
-        },
-        new Object[] {
-          new TestPooledConnectionProxy(notIdleLongEnough),
-          Duration.ofMinutes(1),
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, new PooledConnectionStatistics(0)),
+          IdlePruneStrategy.builder().priority(1).idle(Duration.ofMinutes(1)).build(),
           false,
         },
         new Object[] {
-          new TestPooledConnectionProxy(idleTooLong),
-          Duration.ofMinutes(1),
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, new PooledConnectionStatistics(0)),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(activeConn, new PooledConnectionStatistics(0)),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, noLastAvailableStat),
+          IdlePruneStrategy.builder().priority(1).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, noLastAvailableStat),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(activeConn, noLastAvailableStat),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, notIdleLongEnough),
+          IdlePruneStrategy.builder().priority(1).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, notIdleLongEnough),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(activeConn, notIdleLongEnough),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, idleTooLong),
+          IdlePruneStrategy.builder().priority(1).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, idleTooLong),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(activeConn, idleTooLong),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            passiveConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder()
+            .priority(1)
+            .age(Duration.ofMinutes(5))
+            .idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            passiveConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            passiveConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder()
+            .priority(1)
+            .age(Duration.ofMinutes(5))
+            .idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            passiveConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, noLastAvailableStat, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder()
+            .priority(1)
+            .age(Duration.ofMinutes(5))
+            .idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, noLastAvailableStat, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(activeConn, noLastAvailableStat, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, noLastAvailableStat, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder()
+            .priority(1)
+            .age(Duration.ofMinutes(5))
+            .idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, noLastAvailableStat, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(activeConn, noLastAvailableStat, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, notIdleLongEnough, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder()
+            .priority(1)
+            .age(Duration.ofMinutes(5))
+            .idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, notIdleLongEnough, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(activeConn, notIdleLongEnough, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, notIdleLongEnough, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder()
+            .priority(1)
+            .age(Duration.ofMinutes(5))
+            .idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, notIdleLongEnough, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(activeConn, notIdleLongEnough, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, idleTooLong, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder()
+            .priority(1)
+            .age(Duration.ofMinutes(5))
+            .idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, idleTooLong, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(activeConn, idleTooLong, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, idleTooLong, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder()
+            .priority(1)
+            .age(Duration.ofMinutes(5))
+            .idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(passiveConn, idleTooLong, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePool,
+          new MockPooledConnectionProxy(activeConn, idleTooLong, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        // idlePrunePool should exercise both idle and age pruning
+        new Object[] {
+          idlePrunePool,
+          new MockPooledConnectionProxy(activeConn, new PooledConnectionStatistics(0)),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePrunePool,
+          new MockPooledConnectionProxy(activeConn, noLastAvailableStat),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePrunePool,
+          new MockPooledConnectionProxy(activeConn, notIdleLongEnough),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePrunePool,
+          new MockPooledConnectionProxy(activeConn, idleTooLong),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePrunePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePrunePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePrunePool,
+          new MockPooledConnectionProxy(
+            activeConn, noLastAvailableStat, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePrunePool,
+          new MockPooledConnectionProxy(activeConn, noLastAvailableStat, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePrunePool,
+          new MockPooledConnectionProxy(activeConn, notIdleLongEnough, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePrunePool,
+          new MockPooledConnectionProxy(activeConn, notIdleLongEnough, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          idlePrunePool,
+          new MockPooledConnectionProxy(activeConn, idleTooLong, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          idlePrunePool,
+          new MockPooledConnectionProxy(activeConn, idleTooLong, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        // activePool should only exercise age pruning
+        new Object[] {
+          activePool,
+          new MockPooledConnectionProxy(activeConn, new PooledConnectionStatistics(0)),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          activePool,
+          new MockPooledConnectionProxy(activeConn, noLastAvailableStat),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          activePool,
+          new MockPooledConnectionProxy(activeConn, notIdleLongEnough),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          activePool,
+          new MockPooledConnectionProxy(activeConn, idleTooLong),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          activePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          activePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePool,
+          new MockPooledConnectionProxy(activeConn, noLastAvailableStat, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          activePool,
+          new MockPooledConnectionProxy(activeConn, noLastAvailableStat, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePool,
+          new MockPooledConnectionProxy(activeConn, notIdleLongEnough, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePool,
+          new MockPooledConnectionProxy(activeConn, notIdleLongEnough, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          activePool,
+          new MockPooledConnectionProxy(activeConn, idleTooLong, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePool,
+          new MockPooledConnectionProxy(activeConn, idleTooLong, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        // activePrunePool should exercise both idle and age pruning
+        new Object[] {
+          activePrunePool,
+          new MockPooledConnectionProxy(activeConn, new PooledConnectionStatistics(0)),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePrunePool,
+          new MockPooledConnectionProxy(activeConn, noLastAvailableStat),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePrunePool,
+          new MockPooledConnectionProxy(activeConn, notIdleLongEnough),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          activePrunePool,
+          new MockPooledConnectionProxy(activeConn, idleTooLong),
+          IdlePruneStrategy.builder().idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePrunePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePrunePool,
+          new MockPooledConnectionProxy(
+            activeConn, new PooledConnectionStatistics(0), Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePrunePool,
+          new MockPooledConnectionProxy(activeConn, noLastAvailableStat, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePrunePool,
+          new MockPooledConnectionProxy(activeConn, noLastAvailableStat, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePrunePool,
+          new MockPooledConnectionProxy(activeConn, notIdleLongEnough, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePrunePool,
+          new MockPooledConnectionProxy(activeConn, notIdleLongEnough, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          false,
+        },
+        new Object[] {
+          activePrunePool,
+          new MockPooledConnectionProxy(activeConn, idleTooLong, Instant.now().minus(Duration.ofMinutes(6))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
+          true,
+        },
+        new Object[] {
+          activePrunePool,
+          new MockPooledConnectionProxy(activeConn, idleTooLong, Instant.now().minus(Duration.ofMinutes(3))),
+          IdlePruneStrategy.builder().age(Duration.ofMinutes(5)).idle(Duration.ofMinutes(1)).build(),
           true,
         },
       };
   }
+  // CheckStyle:MethodLength ON
 
 
   /**
    * Unit test for {@link IdlePruneStrategy#apply(PooledConnectionProxy)}.
    *
+   * @param  pool  to prune
    * @param  conn  to apply to strategy
-   * @param  idle  strategy idle duration
+   * @param  strategy  prune strategy
    * @param  result  expected result of the strategy
    */
   @Test(groups = "conn", dataProvider = "conns")
-  public void apply(final PooledConnectionProxy conn, final Duration idle, final boolean result)
+  public void apply(
+    final ConnectionPool pool, final PooledConnectionProxy conn, final IdlePruneStrategy strategy, final boolean result)
   {
-    final IdlePruneStrategy strategy = new IdlePruneStrategy(idle);
-    assertThat(strategy.apply(conn)).isEqualTo(result);
-  }
-
-
-  /** Class to support testing of a {@link PooledConnectionProxy}. */
-  private static class TestPooledConnectionProxy implements PooledConnectionProxy
-  {
-
-    /** Pooled connection statistics. */
-    private final PooledConnectionStatistics connectionStatistics;
-
-    /**
-     * Creates a new test pooled connection proxy.
-     *
-     * @param  statistics  connection statistics
-     */
-    TestPooledConnectionProxy(final PooledConnectionStatistics statistics)
-    {
-      connectionStatistics = statistics;
-    }
-
-
-    @Override
-    public ConnectionPool getConnectionPool()
-    {
-      throw new UnsupportedOperationException();
-    }
-
-
-    @Override
-    public Connection getConnection()
-    {
-      throw new UnsupportedOperationException();
-    }
-
-
-    @Override
-    public long getCreatedTime()
-    {
-      throw new UnsupportedOperationException();
-    }
-
-
-    @Override
-    public PooledConnectionStatistics getPooledConnectionStatistics()
-    {
-      return connectionStatistics;
-    }
-
-
-    @Override
-    public Object invoke(final Object proxy, final Method method, final Object[] args)
-    {
-      throw new UnsupportedOperationException();
-    }
+    assertThat(strategy.apply(conn).stream().anyMatch(p -> p.test(new DefaultPoolState(pool, 3, 10))))
+      .isEqualTo(result);
   }
 }

--- a/core/src/test/java/org/ldaptive/pool/MockConnectionPool.java
+++ b/core/src/test/java/org/ldaptive/pool/MockConnectionPool.java
@@ -1,0 +1,113 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.pool;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.ldaptive.Connection;
+import org.ldaptive.Request;
+import org.ldaptive.Result;
+import org.ldaptive.transport.mock.MockConnection;
+
+/**
+ * Mock connection pool for testing.
+ *
+ * @param  <Q>  type of request
+ * @param  <S>  type of response
+ *
+ * @author  Middleware Services
+ */
+public class MockConnectionPool<Q extends Request, S extends Result> implements ConnectionPool
+{
+
+  /** Available connections. */
+  private final List<MockConnection<Q, S>> availableConns = new ArrayList<>();
+
+  /** Active connections. */
+  private final List<MockConnection<Q, S>> activeConns = new ArrayList<>();
+
+  /** Connection activator. */
+  private ConnectionActivator connectionActivator;
+
+  /** Connection passivator. */
+  private ConnectionPassivator connectionPassivator;
+
+
+  /**
+   * Creates a new mock connection pool.
+   *
+   * @param  available  available connections
+   * @param  active  active connections
+   */
+  public MockConnectionPool(final List<MockConnection<Q, S>> available, final List<MockConnection<Q, S>> active)
+  {
+    availableConns.addAll(available);
+    activeConns.addAll(active);
+  }
+
+
+  @Override
+  public ConnectionActivator getActivator()
+  {
+    return connectionActivator;
+  }
+
+
+  @Override
+  public void setActivator(final ConnectionActivator activator)
+  {
+    connectionActivator = activator;
+  }
+
+
+  @Override
+  public ConnectionPassivator getPassivator()
+  {
+    return connectionPassivator;
+  }
+
+
+  @Override
+  public void setPassivator(final ConnectionPassivator passivator)
+  {
+    connectionPassivator = passivator;
+  }
+
+
+  @Override
+  public void initialize() {}
+
+
+  @Override
+  public Connection getConnection()
+    throws PoolException
+  {
+    return null;
+  }
+
+
+  @Override
+  public int availableCount()
+  {
+    return availableConns.size();
+  }
+
+
+  @Override
+  public int activeCount()
+  {
+    return activeConns.size();
+  }
+
+
+  @Override
+  public Set<PooledConnectionStatistics> getPooledConnectionStatistics()
+  {
+    throw new UnsupportedOperationException();
+  }
+
+
+  @Override
+  public void close() {}
+}

--- a/core/src/test/java/org/ldaptive/pool/MockPooledConnectionProxy.java
+++ b/core/src/test/java/org/ldaptive/pool/MockPooledConnectionProxy.java
@@ -1,0 +1,79 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.pool;
+
+import java.lang.reflect.Method;
+import java.time.Instant;
+import org.ldaptive.Connection;
+
+/**
+ * {@link PooledConnectionProxy} used for testing.
+ *
+ * @author  Middleware Services
+ */
+public class MockPooledConnectionProxy implements PooledConnectionProxy
+{
+
+  /** Connection. */
+  private final Connection connection;
+
+  /** Pooled connection statistics. */
+  private final PooledConnectionStatistics connectionStatistics;
+
+  /** Time this connection was created. */
+  private final Instant createdTime;
+
+
+  /**
+   * Creates a new test pooled connection proxy.
+   *
+   * @param  conn  connection
+   * @param  statistics  connection statistics
+   */
+  public MockPooledConnectionProxy(final Connection conn, final PooledConnectionStatistics statistics)
+  {
+    this(conn, statistics, Instant.now());
+  }
+
+
+  /**
+   * Creates a new test pooled connection proxy.
+   *
+   * @param  conn  connection
+   * @param  statistics  connection statistics
+   * @param  time  creation time
+   */
+  MockPooledConnectionProxy(final Connection conn, final PooledConnectionStatistics statistics, final Instant time)
+  {
+    connection = conn;
+    connectionStatistics = statistics;
+    createdTime = time;
+  }
+
+
+  @Override
+  public Connection getConnection()
+  {
+    return connection;
+  }
+
+
+  @Override
+  public Instant getCreatedTime()
+  {
+    return createdTime;
+  }
+
+
+  @Override
+  public PooledConnectionStatistics getPooledConnectionStatistics()
+  {
+    return connectionStatistics;
+  }
+
+
+  @Override
+  public Object invoke(final Object proxy, final Method method, final Object[] args)
+  {
+    throw new UnsupportedOperationException();
+  }
+}


### PR DESCRIPTION
PruneStrategy encapsulates the entire configuration for pruning, as such it can be difficult to implement complex pruning policies. Previously the connection pool itself restricted pruning such that connection could not be pruned below the minimum pool size. With this patch that logic is moved into the prune strategy allowing any and all available connections to be pruned. As a consequence, the connection pool will now attempt to grow back to its minimum size after pruning is complete. IdlePruneStrategy has been updated to support a max connection age, any connection exceeding that duration is removed from the pool. This provides a guarantee that connections will be eventually recycled when the pool is idle.