### PR TITLE
Support both errors and warnings in AccountState

### DIFF
--- a/core/src/main/java/org/ldaptive/auth/AccountState.java
+++ b/core/src/main/java/org/ldaptive/auth/AccountState.java
@@ -7,8 +7,7 @@ import javax.security.auth.login.LoginException;
 import org.ldaptive.LdapUtils;
 
 /**
- * Represents the state of an LDAP account based on account policies for that LDAP. Note that only warning(s) or
- * error(s) may be set, not both.
+ * Represents the state of an LDAP account based on account policies for that LDAP.
  *
  * @author  Middleware Services
  */
@@ -20,6 +19,32 @@ public class AccountState
 
   /** account error. */
   private final AccountState.Error[] accountErrors;
+
+
+  /**
+   * Creates a new account state.
+   *
+   * @param  warning  associated with the account
+   * @param  error  associated with the account
+   */
+  public AccountState(final AccountState.Warning warning, final AccountState.Error error)
+  {
+    accountWarnings = warning != null ? new AccountState.Warning[] {warning} : null;
+    accountErrors = error != null ? new AccountState.Error[] {error} : null;
+  }
+
+
+  /**
+   * Creates a new account state.
+   *
+   * @param  warnings  associated with the account
+   * @param  errors  associated with the account
+   */
+  public AccountState(final AccountState.Warning[] warnings, final AccountState.Error[] errors)
+  {
+    accountWarnings = LdapUtils.copyArray(warnings);
+    accountErrors = LdapUtils.copyArray(errors);
+  }
 
 
   /**

--- a/core/src/main/java/org/ldaptive/auth/ext/PasswordPolicyAccountState.java
+++ b/core/src/main/java/org/ldaptive/auth/ext/PasswordPolicyAccountState.java
@@ -6,7 +6,8 @@ import org.ldaptive.auth.AccountState;
 import org.ldaptive.control.PasswordPolicyControl;
 
 /**
- * Represents the state of an account as described by a password policy control.
+ * Represents the state of an account as described by a password policy control. The {@link PasswordPolicyControl}
+ * supports a single warning and/or a single error.
  *
  * @author  Middleware Services
  */
@@ -18,7 +19,7 @@ public class PasswordPolicyAccountState extends AccountState
 
 
   /**
-   * Creates a new password policy account state.
+   * Creates a new password policy account state with a timeBeforeExpiration warning.
    *
    * @param  exp  account expiration
    * @param  remaining  number of logins available
@@ -33,11 +34,61 @@ public class PasswordPolicyAccountState extends AccountState
   /**
    * Creates a new password policy account state.
    *
+   * @param  exp  account expiration
+   */
+  public PasswordPolicyAccountState(final ZonedDateTime exp)
+  {
+    super(new AccountState.DefaultWarning(exp, -1));
+    ppError = null;
+  }
+
+
+  /**
+   * Creates a new password policy account state with a graceAuthNsRemaining warning.
+   *
+   * @param  remaining  number of logins available
+   */
+  public PasswordPolicyAccountState(final int remaining)
+  {
+    super(new AccountState.DefaultWarning(null, remaining));
+    ppError = null;
+  }
+
+
+  /**
+   * Creates a new password policy account state with an error.
+   *
    * @param  error  containing password policy error details
    */
   public PasswordPolicyAccountState(final PasswordPolicyControl.Error error)
   {
     super(error);
+    ppError = error;
+  }
+
+
+  /**
+   * Creates a new password policy account state with both a timeBeforeExpiration warning and an error.
+   *
+   * @param  exp  account expiration
+   * @param  error  containing password policy error details
+   */
+  public PasswordPolicyAccountState(final ZonedDateTime exp, final PasswordPolicyControl.Error error)
+  {
+    super(new AccountState.DefaultWarning(exp, -1), error);
+    ppError = error;
+  }
+
+
+  /**
+   * Creates a new password policy account state with both a graceAuthNsRemaining warning and an error.
+   *
+   * @param  remaining  number of logins available
+   * @param  error  containing password policy error details
+   */
+  public PasswordPolicyAccountState(final int remaining, final PasswordPolicyControl.Error error)
+  {
+    super(new AccountState.DefaultWarning(null, remaining), error);
     ppError = error;
   }
 

--- a/core/src/main/java/org/ldaptive/auth/ext/PasswordPolicyAccountState.java
+++ b/core/src/main/java/org/ldaptive/auth/ext/PasswordPolicyAccountState.java
@@ -22,19 +22,6 @@ public class PasswordPolicyAccountState extends AccountState
    * Creates a new password policy account state with a timeBeforeExpiration warning.
    *
    * @param  exp  account expiration
-   * @param  remaining  number of logins available
-   */
-  public PasswordPolicyAccountState(final ZonedDateTime exp, final int remaining)
-  {
-    super(new AccountState.DefaultWarning(exp, remaining));
-    ppError = null;
-  }
-
-
-  /**
-   * Creates a new password policy account state.
-   *
-   * @param  exp  account expiration
    */
   public PasswordPolicyAccountState(final ZonedDateTime exp)
   {

--- a/core/src/main/java/org/ldaptive/auth/ext/PasswordPolicyAuthenticationResponseHandler.java
+++ b/core/src/main/java/org/ldaptive/auth/ext/PasswordPolicyAuthenticationResponseHandler.java
@@ -47,18 +47,19 @@ public class PasswordPolicyAuthenticationResponseHandler implements Authenticati
     if (ppc != null) {
       final ZonedDateTime exp = getTimeBeforeExpiration(ppc);
       if (exp != null) {
-        if (ppc.getError() != null) {
+        if (ppc.hasError()) {
           response.setAccountState(new PasswordPolicyAccountState(exp, ppc.getError()));
         } else {
           response.setAccountState(new PasswordPolicyAccountState(exp));
         }
-      } else if (ppc.getGraceAuthNsRemaining() >= 0) {
-        if (ppc.getError() != null) {
-          response.setAccountState(new PasswordPolicyAccountState(ppc.getGraceAuthNsRemaining(), ppc.getError()));
+      } else if (ppc.hasWarning(PasswordPolicyControl.WarningType.GRACE_AUTHNS_REMAINING)) {
+        final int graceAuthnsRemaining = ppc.getWarning().getValue();
+        if (ppc.hasError()) {
+          response.setAccountState(new PasswordPolicyAccountState(graceAuthnsRemaining, ppc.getError()));
         } else {
-          response.setAccountState(new PasswordPolicyAccountState(ppc.getGraceAuthNsRemaining()));
+          response.setAccountState(new PasswordPolicyAccountState(graceAuthnsRemaining));
         }
-      } else if (ppc.getError() != null) {
+      } else if (ppc.hasError()) {
         response.setAccountState(new PasswordPolicyAccountState(ppc.getError()));
       }
     }
@@ -74,8 +75,8 @@ public class PasswordPolicyAuthenticationResponseHandler implements Authenticati
    */
   private ZonedDateTime getTimeBeforeExpiration(final PasswordPolicyControl ppc)
   {
-    if (ppc.getTimeBeforeExpiration() >= 0) {
-      return ZonedDateTime.now(expirationClock).plusSeconds(ppc.getTimeBeforeExpiration());
+    if (ppc.hasWarning(PasswordPolicyControl.WarningType.TIME_BEFORE_EXPIRATION)) {
+      return ZonedDateTime.now(expirationClock).plusSeconds(ppc.getWarning().getValue());
     }
     return null;
   }

--- a/core/src/main/java/org/ldaptive/auth/ext/PasswordPolicyAuthenticationResponseHandler.java
+++ b/core/src/main/java/org/ldaptive/auth/ext/PasswordPolicyAuthenticationResponseHandler.java
@@ -1,6 +1,7 @@
 /* See LICENSE for licensing and NOTICE for copyright. */
 package org.ldaptive.auth.ext;
 
+import java.time.Clock;
 import java.time.ZonedDateTime;
 import org.ldaptive.auth.AuthenticationResponse;
 import org.ldaptive.auth.AuthenticationResponseHandler;
@@ -15,23 +16,67 @@ import org.ldaptive.control.PasswordPolicyControl;
 public class PasswordPolicyAuthenticationResponseHandler implements AuthenticationResponseHandler
 {
 
+  /** Clock to convert time before expiration seconds to a datetime. */
+  private final Clock expirationClock;
+
+
+  /**
+   * Creates a new password policy authentication response handler.
+   */
+  public PasswordPolicyAuthenticationResponseHandler()
+  {
+    this(Clock.systemDefaultZone());
+  }
+
+
+  /**
+   * Creates a new password policy authentication response handler.
+   *
+   * @param  clock  used to convert time before expiration to a datetime
+   */
+  PasswordPolicyAuthenticationResponseHandler(final Clock clock)
+  {
+    expirationClock = clock;
+  }
+
 
   @Override
   public void handle(final AuthenticationResponse response)
   {
     final PasswordPolicyControl ppc = (PasswordPolicyControl) response.getControl(PasswordPolicyControl.OID);
     if (ppc != null) {
-      if (ppc.getError() != null) {
+      final ZonedDateTime exp = getTimeBeforeExpiration(ppc);
+      if (exp != null) {
+        if (ppc.getError() != null) {
+          response.setAccountState(new PasswordPolicyAccountState(exp, ppc.getError()));
+        } else {
+          response.setAccountState(new PasswordPolicyAccountState(exp));
+        }
+      } else if (ppc.getGraceAuthNsRemaining() >= 0) {
+        if (ppc.getError() != null) {
+          response.setAccountState(new PasswordPolicyAccountState(ppc.getGraceAuthNsRemaining(), ppc.getError()));
+        } else {
+          response.setAccountState(new PasswordPolicyAccountState(ppc.getGraceAuthNsRemaining()));
+        }
+      } else if (ppc.getError() != null) {
         response.setAccountState(new PasswordPolicyAccountState(ppc.getError()));
-      } else {
-        ZonedDateTime exp = null;
-        if (ppc.getTimeBeforeExpiration() >= 0) {
-          exp = ZonedDateTime.now().plusSeconds(ppc.getTimeBeforeExpiration());
-        }
-        if (exp != null || ppc.getGraceAuthNsRemaining() >= 0) {
-          response.setAccountState(new PasswordPolicyAccountState(exp, ppc.getGraceAuthNsRemaining()));
-        }
       }
     }
+  }
+
+
+  /**
+   * Returns a zoned date time for the time before expiration on the supplied control.
+   *
+   * @param  ppc  to inspect
+   *
+   * @return  date time or null
+   */
+  private ZonedDateTime getTimeBeforeExpiration(final PasswordPolicyControl ppc)
+  {
+    if (ppc.getTimeBeforeExpiration() >= 0) {
+      return ZonedDateTime.now(expirationClock).plusSeconds(ppc.getTimeBeforeExpiration());
+    }
+    return null;
   }
 }

--- a/core/src/main/java/org/ldaptive/control/PasswordPolicyControl.java
+++ b/core/src/main/java/org/ldaptive/control/PasswordPolicyControl.java
@@ -191,6 +191,93 @@ public class PasswordPolicyControl extends AbstractControl implements RequestCon
   }
 
 
+  /**
+   * Creates a new password policy control.
+   *
+   * @param  time  time before expiration
+   * @param  count  grace authns remaining
+   */
+  public PasswordPolicyControl(final int time, final int count)
+  {
+    super(OID);
+    setTimeBeforeExpiration(time);
+    setGraceAuthNsRemaining(count);
+  }
+
+
+  /**
+   * Creates a new password policy control.
+   *
+   * @param  time  time before expiration
+   * @param  count  grace authns remaining
+   * @param  critical  whether this control is critical
+   */
+  public PasswordPolicyControl(final int time, final int count, final boolean critical)
+  {
+    super(OID, critical);
+    setTimeBeforeExpiration(time);
+    setGraceAuthNsRemaining(count);
+  }
+
+
+  /**
+   * Creates a new password policy control.
+   *
+   * @param  err  ppolicy error
+   */
+  public PasswordPolicyControl(final Error err)
+  {
+    super(OID);
+    setError(err);
+  }
+
+
+  /**
+   * Creates a new password policy control.
+   *
+   * @param  err  ppolicy error
+   * @param  critical  whether this control is critical
+   */
+  public PasswordPolicyControl(final Error err, final boolean critical)
+  {
+    super(OID, critical);
+    setError(err);
+  }
+
+
+  /**
+   * Creates a new password policy control.
+   *
+   * @param  time  time before expiration
+   * @param  count  grace authns remaining
+   * @param  err  ppolicy error
+   */
+  public PasswordPolicyControl(final int time, final int count, final Error err)
+  {
+    super(OID);
+    setTimeBeforeExpiration(time);
+    setGraceAuthNsRemaining(count);
+    setError(err);
+  }
+
+
+  /**
+   * Creates a new password policy control.
+   *
+   * @param  time  time before expiration
+   * @param  count  grace authns remaining
+   * @param  err  ppolicy error
+   * @param  critical  whether this control is critical
+   */
+  public PasswordPolicyControl(final int time, final int count, final Error err, final boolean critical)
+  {
+    super(OID, critical);
+    setTimeBeforeExpiration(time);
+    setGraceAuthNsRemaining(count);
+    setError(err);
+  }
+
+
   @Override
   public boolean hasValue()
   {

--- a/core/src/test/java/org/ldaptive/auth/ext/AbstractAuthenticationResponseHandlerTest.java
+++ b/core/src/test/java/org/ldaptive/auth/ext/AbstractAuthenticationResponseHandlerTest.java
@@ -1,0 +1,136 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.auth.ext;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.ldaptive.BindResponse;
+import org.ldaptive.LdapAttribute;
+import org.ldaptive.LdapEntry;
+import org.ldaptive.ResultCode;
+import org.ldaptive.auth.AccountState;
+import org.ldaptive.auth.AuthenticationHandlerResponse;
+import org.ldaptive.auth.AuthenticationResponse;
+import org.ldaptive.auth.AuthenticationResponseHandler;
+import org.ldaptive.auth.AuthenticationResultCode;
+import org.ldaptive.control.ResponseControl;
+import org.testng.annotations.Test;
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Base class for authentication response handler tests.
+ *
+ * @author  Middleware Services
+ */
+public abstract class AbstractAuthenticationResponseHandlerTest
+{
+
+  /** clock used for testing. */
+  protected final Clock clock = Clock.fixed(Instant.now(), ZoneId.systemDefault());
+
+
+  /**
+   * Creates a new authentication response for testing.
+   *
+   * @param  authResultCode  authentication result code
+   * @param  control  to add to the response
+   * @param  attrs  attributes to add to the entry
+   *
+   * @return  authentication response
+   */
+  protected AuthenticationResponse createAuthenticationResponse(
+    final AuthenticationResultCode authResultCode,
+    final ResponseControl control,
+    final LdapAttribute... attrs)
+  {
+    return new AuthenticationResponse(
+      new AuthenticationHandlerResponse(
+        BindResponse.builder()
+          .resultCode(authResultCode == AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS ?
+            ResultCode.SUCCESS : ResultCode.INVALID_CREDENTIALS)
+          .controls(control)
+          .build(),
+        authResultCode,
+        null),
+      "cn=test",
+      LdapEntry.builder().dn("cn=test").attributes(attrs).build());
+  }
+
+
+  /**
+   * Creates a new authentication response for testing.
+   *
+   * @param  authResultCode  authentication result code
+   * @param  diagnosticMessage  response diagnostic message
+   * @param  attrs  attributes to add to the entry
+   *
+   * @return  authentication response
+   */
+  protected AuthenticationResponse createAuthenticationResponse(
+    final AuthenticationResultCode authResultCode,
+    final String diagnosticMessage,
+    final LdapAttribute... attrs)
+  {
+    return new AuthenticationResponse(
+      new AuthenticationHandlerResponse(
+        BindResponse.builder()
+          .resultCode(authResultCode == AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS ?
+            ResultCode.SUCCESS : ResultCode.INVALID_CREDENTIALS)
+          .diagnosticMessage(diagnosticMessage)
+          .build(),
+        authResultCode,
+        null),
+      "cn=test",
+      LdapEntry.builder().dn("cn=test").attributes(attrs).build());
+  }
+
+
+  /**
+   * Creates a new authentication response for testing.
+   *
+   * @param  resultCode  bind result code
+   * @param  authResultCode  authentication result code
+   * @param  diagnosticMessage  response diagnostic message
+   * @param  attrs  attributes to add to the entry
+   *
+   * @return  authentication response
+   */
+  protected AuthenticationResponse createAuthenticationResponse(
+    final ResultCode resultCode,
+    final AuthenticationResultCode authResultCode,
+    final String diagnosticMessage,
+    final LdapAttribute... attrs)
+  {
+    return new AuthenticationResponse(
+      new AuthenticationHandlerResponse(
+        BindResponse.builder()
+          .resultCode(resultCode)
+          .diagnosticMessage(diagnosticMessage)
+          .build(),
+        authResultCode,
+        null),
+      "cn=test",
+      LdapEntry.builder().dn("cn=test").attributes(attrs).build());
+  }
+
+
+  /**
+   * Tests response handling.
+   *
+   * @param  handler  response handler to test
+   * @param  response  to handle
+   * @param  state  to compare
+   *
+   * @throws  Exception  On test failure.
+   */
+  @Test(groups = "auth-ext", dataProvider = "responses")
+  public void parse(
+    final AuthenticationResponseHandler handler,
+    final AuthenticationResponse response,
+    final AccountState state)
+    throws Exception
+  {
+    handler.handle(response);
+    assertThat(response.getAccountState()).usingRecursiveComparison().isEqualTo(state);
+  }
+}

--- a/core/src/test/java/org/ldaptive/auth/ext/ActiveDirectoryAuthenticationResponseHandlerTest.java
+++ b/core/src/test/java/org/ldaptive/auth/ext/ActiveDirectoryAuthenticationResponseHandlerTest.java
@@ -1,0 +1,253 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.auth.ext;
+
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import org.ldaptive.LdapAttribute;
+import org.ldaptive.ad.transcode.FileTimeValueTranscoder;
+import org.ldaptive.auth.AuthenticationResultCode;
+import org.testng.annotations.DataProvider;
+
+/**
+ * Unit test for {@link ActiveDirectoryAuthenticationResponseHandler}.
+ *
+ * @author  Middleware Services
+ */
+public class ActiveDirectoryAuthenticationResponseHandlerTest extends AbstractAuthenticationResponseHandlerTest
+{
+
+
+  /**
+   * Password expiration test data.
+   *
+   * @return  error messages
+   */
+  @DataProvider(name = "responses")
+  public Object[][] createTestParams()
+  {
+    return
+      new Object[][] {
+        // auth success no expiration
+        new Object[] {
+          createHandler(null, null),
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS, (String) null),
+          null,
+        },
+        // auth failure no diagnostic message
+        new Object[] {
+          createHandler(null, null),
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE, (String) null),
+          null,
+        },
+        // auth failure empty diagnostic message
+        new Object[] {
+          createHandler(null, null),
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE, ""),
+          null,
+        },
+        // auth failure with unknown diagnostic message
+        new Object[] {
+          createHandler(null, null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE,
+            "unknown diagnostic message"),
+          null,
+        },
+        // auth failure with account disabled diagnostic message
+        new Object[] {
+          createHandler(null, null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE,
+            "80090308: LdapErr: DSID-0C09030B, comment: AcceptSecurityContext error, data 533, v893"),
+          new ActiveDirectoryAccountState(ActiveDirectoryAccountState.Error.ACCOUNT_DISABLED),
+        },
+        // auth success with no pwdLastSet attribute found
+        new Object[] {
+          createHandler(Period.ofDays(30), null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            ""),
+          null,
+        },
+        // auth success with pwdLastSet, no expiration period and no warning period
+        new Object[] {
+          createHandler(null, null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("pwdLastSet")
+              .values(new FileTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).minusDays(10)))
+              .build()),
+          null,
+        },
+        // auth success with pwdLastSet, expiration period and no warning period
+        new Object[] {
+          createHandler(Period.ofDays(30), null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("pwdLastSet")
+              .values(new FileTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).minusDays(10)))
+              .build()),
+          new ActiveDirectoryAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .minusDays(10)
+              .plusDays(30)),
+        },
+        // auth success with pwdLastSet, expiration period inside of warning period
+        new Object[] {
+          createHandler(Period.ofDays(30), Period.ofDays(5)),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("pwdLastSet")
+              .values(new FileTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).minusDays(26)))
+              .build()),
+          new ActiveDirectoryAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .minusDays(26)
+              .plusDays(30)),
+        },
+        // auth success with pwdLastSet, expiration period outside of warning period
+        new Object[] {
+          createHandler(Period.ofDays(30), Period.ofDays(5)),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("pwdLastSet")
+              .values(new FileTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).minusDays(24)))
+              .build()),
+          null,
+        },
+        // auth success with msDS-UserPasswordExpiryTimeComputed, no expiration period, no warning period
+        new Object[] {
+          createHandler(null, null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("msDS-UserPasswordExpiryTimeComputed")
+              .values(new FileTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(13)))
+              .build()),
+          new ActiveDirectoryAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(13)),
+        },
+        // auth success with msDS-UserPasswordExpiryTimeComputed, ignored expiration period, no warning period
+        new Object[] {
+          createHandler(Period.ofDays(30), null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("msDS-UserPasswordExpiryTimeComputed")
+              .values(new FileTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(13)))
+              .build()),
+          new ActiveDirectoryAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(13)),
+        },
+        // auth success with msDS-UserPasswordExpiryTimeComputed and pwdLastSet, no expiration period, no warning period
+        new Object[] {
+          createHandler(null, null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("pwdLastSet")
+              .values(new FileTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).minusDays(24)))
+              .build(),
+            LdapAttribute.builder()
+              .name("msDS-UserPasswordExpiryTimeComputed")
+              .values(new FileTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(13)))
+              .build()),
+          new ActiveDirectoryAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(13)),
+        },
+        // auth success with msDS-UserPasswordExpiryTimeComputed and pwdLastSet
+        // ignored expiration period, no warning period
+        new Object[] {
+          createHandler(Period.ofDays(30), null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("pwdLastSet")
+              .values(new FileTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).minusDays(24)))
+              .build(),
+            LdapAttribute.builder()
+              .name("msDS-UserPasswordExpiryTimeComputed")
+              .values(new FileTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(13)))
+              .build()),
+          new ActiveDirectoryAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(13)),
+        },
+        // auth success with msDS-UserPasswordExpiryTimeComputed, expiration period inside of warning period
+        new Object[] {
+          createHandler(null, Period.ofDays(5)),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("msDS-UserPasswordExpiryTimeComputed")
+              .values(new FileTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(4)))
+              .build()),
+          new ActiveDirectoryAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(4)),
+        },
+        // auth success with msDS-UserPasswordExpiryTimeComputed, expiration period outside of warning period
+        new Object[] {
+          createHandler(null, Period.ofDays(5)),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("msDS-UserPasswordExpiryTimeComputed")
+              .values(new FileTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(13)))
+              .build()),
+          null,
+        },
+      };
+  }
+
+
+  /**
+   * Creates a new active directory authentication response handler.
+   *
+   * @param  exp  expiration period
+   * @param  warning  warning period
+   *
+   * @return  new active directory authentication response handler
+   */
+  private ActiveDirectoryAuthenticationResponseHandler createHandler(final Period exp, final Period warning)
+  {
+    final ActiveDirectoryAuthenticationResponseHandler handler =
+      new ActiveDirectoryAuthenticationResponseHandler(clock);
+    handler.setExpirationPeriod(exp);
+    handler.setWarningPeriod(warning);
+    return handler;
+  }
+}

--- a/core/src/test/java/org/ldaptive/auth/ext/EDirectoryAuthenticationResponseHandlerTest.java
+++ b/core/src/test/java/org/ldaptive/auth/ext/EDirectoryAuthenticationResponseHandlerTest.java
@@ -1,0 +1,195 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.auth.ext;
+
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import org.ldaptive.LdapAttribute;
+import org.ldaptive.auth.AuthenticationResultCode;
+import org.ldaptive.transcode.GeneralizedTimeValueTranscoder;
+import org.testng.annotations.DataProvider;
+
+/**
+ * Unit test for {@link EDirectoryAuthenticationResponseHandler}.
+ *
+ * @author  Middleware Services
+ */
+public class EDirectoryAuthenticationResponseHandlerTest extends AbstractAuthenticationResponseHandlerTest
+{
+
+
+  /**
+   * Password expiration test data.
+   *
+   * @return  error messages
+   */
+  @DataProvider(name = "responses")
+  public Object[][] createTestParams()
+  {
+    return
+      new Object[][] {
+        // auth success no expiration
+        new Object[] {
+          createHandler(null),
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS, (String) null),
+          null,
+        },
+        // auth failure no diagnostic message
+        new Object[] {
+          createHandler(null),
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE, (String) null),
+          null,
+        },
+        // auth failure empty diagnostic message
+        new Object[] {
+          createHandler(null),
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE, ""),
+          null,
+        },
+        // auth failure with unknown diagnostic message
+        new Object[] {
+          createHandler(null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE,
+            "unknown diagnostic message"),
+          null,
+        },
+        // auth failure with account disabled diagnostic message
+        new Object[] {
+          createHandler(null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE,
+            "LDAP: error code 49 - NDS error: password expired (-223)"),
+          new EDirectoryAccountState(EDirectoryAccountState.Error.PASSWORD_EXPIRED),
+        },
+        // auth success with no attributes found
+        new Object[] {
+          createHandler(null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            ""),
+          null,
+        },
+        // auth success with loginGraceRemaining, no passwordExpirationTime and no warning period
+        new Object[] {
+          createHandler(null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder().name("loginGraceRemaining").values("3").build()),
+          new EDirectoryAccountState(null, 3),
+        },
+        // auth success with passwordExpirationTime, no loginGraceRemaining and no warning period
+        new Object[] {
+          createHandler(null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("passwordExpirationTime")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(10)))
+              .build()),
+          new EDirectoryAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(10),
+            0),
+        },
+        // auth success with passwordExpirationTime and loginGraceRemaining, no warning period
+        new Object[] {
+          createHandler(null),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("passwordExpirationTime")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(10)))
+              .build(),
+          LdapAttribute.builder().name("loginGraceRemaining").values("3").build()),
+          new EDirectoryAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(10),
+            3),
+        },
+        // auth success with passwordExpirationTime and outside warning period, no loginGraceRemaining
+        new Object[] {
+          createHandler(Period.ofDays(5)),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("passwordExpirationTime")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(10)))
+              .build()),
+          null,
+        },
+        // auth success with passwordExpirationTime and inside warning period, no loginGraceRemaining
+        new Object[] {
+          createHandler(Period.ofDays(5)),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("passwordExpirationTime")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(4)))
+              .build()),
+          new EDirectoryAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(4),
+            0),
+        },
+        // auth success with passwordExpirationTime, loginGraceRemaining and outside warning period
+        new Object[] {
+          createHandler(Period.ofDays(5)),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("passwordExpirationTime")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(10)))
+              .build(),
+          LdapAttribute.builder().name("loginGraceRemaining").values("3").build()),
+          null,
+        },
+        // auth success with passwordExpirationTime, loginGraceRemaining and inside warning period
+        new Object[] {
+          createHandler(Period.ofDays(5)),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("passwordExpirationTime")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(4)))
+              .build(),
+          LdapAttribute.builder().name("loginGraceRemaining").values("3").build()),
+          new EDirectoryAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(4),
+            3),
+        },
+      };
+  }
+
+
+  /**
+   * Creates a new edirectory authentication response handler.
+   *
+   * @param  warning  warning period
+   *
+   * @return  new edirectory authentication response handler
+   */
+  private EDirectoryAuthenticationResponseHandler createHandler(final Period warning)
+  {
+    final EDirectoryAuthenticationResponseHandler handler = new EDirectoryAuthenticationResponseHandler(clock);
+    handler.setWarningPeriod(warning);
+    return handler;
+  }
+}

--- a/core/src/test/java/org/ldaptive/auth/ext/FreeIPAAuthenticationResponseHandlerTest.java
+++ b/core/src/test/java/org/ldaptive/auth/ext/FreeIPAAuthenticationResponseHandlerTest.java
@@ -1,0 +1,247 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.auth.ext;
+
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import org.ldaptive.LdapAttribute;
+import org.ldaptive.ResultCode;
+import org.ldaptive.auth.AuthenticationResultCode;
+import org.ldaptive.transcode.GeneralizedTimeValueTranscoder;
+import org.testng.annotations.DataProvider;
+
+/**
+ * Unit test for {@link FreeIPAAuthenticationResponseHandler}.
+ *
+ * @author  Middleware Services
+ */
+public class FreeIPAAuthenticationResponseHandlerTest extends AbstractAuthenticationResponseHandlerTest
+{
+
+
+  /**
+   * Password expiration test data.
+   *
+   * @return  error messages
+   */
+  @DataProvider(name = "responses")
+  public Object[][] createTestParams()
+  {
+    return
+      new Object[][] {
+        // auth success no expiration
+        new Object[] {
+          createHandler(null, null, 0),
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS, (String) null),
+          null,
+        },
+        // auth failure no diagnostic message
+        new Object[] {
+          createHandler(null, null, 0),
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE, (String) null),
+          new FreeIPAAccountState(FreeIPAAccountState.Error.CREDENTIAL_NOT_FOUND),
+        },
+        // auth failure empty diagnostic message
+        new Object[] {
+          createHandler(null, null, 0),
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE, ""),
+          new FreeIPAAccountState(FreeIPAAccountState.Error.CREDENTIAL_NOT_FOUND),
+        },
+        // auth failure with unknown diagnostic message
+        new Object[] {
+          createHandler(null, null, 0),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE,
+            "unknown diagnostic message"),
+          new FreeIPAAccountState(FreeIPAAccountState.Error.CREDENTIAL_NOT_FOUND),
+        },
+        // auth failure with account disabled diagnostic message
+        new Object[] {
+          createHandler(null, null, 0),
+          createAuthenticationResponse(
+            ResultCode.UNWILLING_TO_PERFORM,
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE,
+            "Account (Kerberos principal) is expired"),
+          new FreeIPAAccountState(FreeIPAAccountState.Error.ACCOUNT_EXPIRED),
+        },
+        // auth success with no attributes found
+        new Object[] {
+          createHandler(null, null, 0),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            ""),
+          null,
+        },
+        // auth success with maxLoginFailures and no attribute, no expiration period and no warning period
+        new Object[] {
+          createHandler(null, null, 5),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            ""),
+          null,
+        },
+        // auth success with maxLoginFailures and attribute, no expiration period and no warning period
+        new Object[] {
+          createHandler(null, null, 5),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder().name("krbLoginFailedCount").values("3").build()),
+          new FreeIPAAccountState(null, 2),
+        },
+        // auth success with expiration, no maxLoginFailures, no expiration period, no warning period
+        new Object[] {
+          createHandler(null, null, 0),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("krbPasswordExpiration")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(10)))
+              .build()),
+          new FreeIPAAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(10),
+            0),
+        },
+        // auth success with maxLoginFailures and expiration, no expiration period and no warning period
+        new Object[] {
+          createHandler(null, null, 5),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder().name("krbLoginFailedCount").values("3").build(),
+            LdapAttribute.builder()
+              .name("krbPasswordExpiration")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(10)))
+              .build()),
+          new FreeIPAAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(10),
+            2),
+        },
+        // auth success with password change, no maxLoginFailures, expiration period, no warning period
+        new Object[] {
+          createHandler(Period.ofDays(30), null, 0),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder()
+              .name("krbLastPwdChange")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).minusDays(14)))
+              .build()),
+          new FreeIPAAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(16),
+            0),
+        },
+        // auth success with maxLoginFailures, password change, expiration period and no warning period
+        new Object[] {
+          createHandler(Period.ofDays(30), null, 5),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder().name("krbLoginFailedCount").values("3").build(),
+            LdapAttribute.builder()
+              .name("krbLastPwdChange")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).minusDays(14)))
+              .build()),
+          new FreeIPAAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(16),
+            2),
+        },
+        // auth success with maxLoginFailures, expiration, expiration period and warning period
+        new Object[] {
+          createHandler(Period.ofDays(30), Period.ofDays(5), 5),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder().name("krbLoginFailedCount").values("3").build(),
+            LdapAttribute.builder()
+              .name("krbPasswordExpiration")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(10)))
+              .build()),
+          null,
+        },
+        // auth success with maxLoginFailures, expiration, expiration period and warning period
+        new Object[] {
+          createHandler(Period.ofDays(30), Period.ofDays(5), 5),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder().name("krbLoginFailedCount").values("3").build(),
+            LdapAttribute.builder()
+              .name("krbPasswordExpiration")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).plusDays(4)))
+              .build()),
+          new FreeIPAAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(4),
+            2),
+        },
+        // auth success with maxLoginFailures, password change, expiration period and warning period
+        new Object[] {
+          createHandler(Period.ofDays(30), Period.ofDays(5), 5),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder().name("krbLoginFailedCount").values("3").build(),
+            LdapAttribute.builder()
+              .name("krbLastPwdChange")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).minusDays(14)))
+              .build()),
+          null,
+        },
+        // auth success with maxLoginFailures, password change, expiration period and warning period
+        new Object[] {
+          createHandler(Period.ofDays(30), Period.ofDays(5), 5),
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            "",
+            LdapAttribute.builder().name("krbLoginFailedCount").values("3").build(),
+            LdapAttribute.builder()
+              .name("krbLastPwdChange")
+              .values(new GeneralizedTimeValueTranscoder().encodeStringValue(ZonedDateTime.now(clock).minusDays(26)))
+              .build()),
+          new FreeIPAAccountState(
+            ZonedDateTime.now(clock)
+              .truncatedTo(ChronoUnit.MILLIS)
+              .withZoneSameInstant(ZoneId.of("Z"))
+              .plusDays(4),
+            2),
+        },
+      };
+  }
+
+
+  /**
+   * Creates a new freeipa authentication response handler.
+   *
+   * @param  exp  expiration period
+   * @param  warning  warning period
+   * @param  loginFailures  max login failures
+   *
+   * @return  new freeipa authentication response handler
+   */
+  private FreeIPAAuthenticationResponseHandler createHandler(
+    final Period exp, final Period warning, final int loginFailures)
+  {
+    final FreeIPAAuthenticationResponseHandler handler = new FreeIPAAuthenticationResponseHandler(clock);
+    handler.setExpirationPeriod(exp);
+    handler.setWarningPeriod(warning);
+    handler.setMaxLoginFailures(loginFailures);
+    return handler;
+  }
+}

--- a/core/src/test/java/org/ldaptive/auth/ext/PasswordExpirationAuthenticationResponseHandlerTest.java
+++ b/core/src/test/java/org/ldaptive/auth/ext/PasswordExpirationAuthenticationResponseHandlerTest.java
@@ -1,0 +1,62 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.auth.ext;
+
+import java.time.ZonedDateTime;
+import org.ldaptive.auth.AuthenticationResultCode;
+import org.ldaptive.control.PasswordExpiredControl;
+import org.ldaptive.control.PasswordExpiringControl;
+import org.ldaptive.control.ResponseControl;
+import org.testng.annotations.DataProvider;
+
+/**
+ * Unit test for {@link PasswordExpirationAuthenticationResponseHandler}.
+ *
+ * @author  Middleware Services
+ */
+public class PasswordExpirationAuthenticationResponseHandlerTest extends AbstractAuthenticationResponseHandlerTest
+{
+
+  /** handler to test. */
+  private final PasswordExpirationAuthenticationResponseHandler handler =
+    new PasswordExpirationAuthenticationResponseHandler(clock);
+
+
+  /**
+   * Password expiration test data.
+   *
+   * @return  error messages
+   */
+  @DataProvider(name = "responses")
+  public Object[][] createTestParams()
+  {
+    final int expirationTimeSeconds = 123456;
+    final ZonedDateTime exp = ZonedDateTime.now(clock).plusSeconds(expirationTimeSeconds);
+    return
+      new Object[][] {
+        new Object[] {
+          handler,
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS, (ResponseControl) null),
+          null,
+        },
+        new Object[] {
+          handler,
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE, (ResponseControl) null),
+          null,
+        },
+        new Object[] {
+          handler,
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            new PasswordExpiredControl()),
+          new PasswordExpirationAccountState(PasswordExpirationAccountState.Error.PASSWORD_EXPIRED),
+        },
+        new Object[] {
+          handler,
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            new PasswordExpiringControl(expirationTimeSeconds)),
+          new PasswordExpirationAccountState(exp),
+        },
+      };
+  }
+}

--- a/core/src/test/java/org/ldaptive/auth/ext/PasswordPolicyAuthenticationResponseHandlerTest.java
+++ b/core/src/test/java/org/ldaptive/auth/ext/PasswordPolicyAuthenticationResponseHandlerTest.java
@@ -53,28 +53,34 @@ public class PasswordPolicyAuthenticationResponseHandlerTest extends AbstractAut
           handler,
           createAuthenticationResponse(
             AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
-            new PasswordPolicyControl(-1, 5)),
+            new PasswordPolicyControl(PasswordPolicyControl.WarningType.GRACE_AUTHNS_REMAINING, 5)),
           new PasswordPolicyAccountState(5),
         },
         new Object[] {
           handler,
           createAuthenticationResponse(
             AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
-            new PasswordPolicyControl(-1, 5, PasswordPolicyControl.Error.PASSWORD_EXPIRED)),
+            new PasswordPolicyControl(
+              PasswordPolicyControl.WarningType.GRACE_AUTHNS_REMAINING,
+              5,
+              PasswordPolicyControl.Error.PASSWORD_EXPIRED)),
           new PasswordPolicyAccountState(5, PasswordPolicyControl.Error.PASSWORD_EXPIRED),
         },
         new Object[] {
           handler,
           createAuthenticationResponse(
             AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
-            new PasswordPolicyControl(expirationTimeSeconds, -1)),
+            new PasswordPolicyControl(PasswordPolicyControl.WarningType.TIME_BEFORE_EXPIRATION, expirationTimeSeconds)),
           new PasswordPolicyAccountState(exp),
         },
         new Object[] {
           handler,
           createAuthenticationResponse(
             AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
-            new PasswordPolicyControl(expirationTimeSeconds, -1, PasswordPolicyControl.Error.PASSWORD_EXPIRED)),
+            new PasswordPolicyControl(
+              PasswordPolicyControl.WarningType.TIME_BEFORE_EXPIRATION,
+              expirationTimeSeconds,
+              PasswordPolicyControl.Error.PASSWORD_EXPIRED)),
           new PasswordPolicyAccountState(exp, PasswordPolicyControl.Error.PASSWORD_EXPIRED),
         },
       };

--- a/core/src/test/java/org/ldaptive/auth/ext/PasswordPolicyAuthenticationResponseHandlerTest.java
+++ b/core/src/test/java/org/ldaptive/auth/ext/PasswordPolicyAuthenticationResponseHandlerTest.java
@@ -1,0 +1,82 @@
+/* See LICENSE for licensing and NOTICE for copyright. */
+package org.ldaptive.auth.ext;
+
+import java.time.ZonedDateTime;
+import org.ldaptive.auth.AuthenticationResultCode;
+import org.ldaptive.control.PasswordPolicyControl;
+import org.ldaptive.control.ResponseControl;
+import org.testng.annotations.DataProvider;
+
+/**
+ * Unit test for {@link PasswordPolicyAuthenticationResponseHandler}.
+ *
+ * @author  Middleware Services
+ */
+public class PasswordPolicyAuthenticationResponseHandlerTest extends AbstractAuthenticationResponseHandlerTest
+{
+
+  /** handler to test. */
+  private final PasswordPolicyAuthenticationResponseHandler handler =
+    new PasswordPolicyAuthenticationResponseHandler(clock);
+
+
+  /**
+   * Password expiration test data.
+   *
+   * @return  error messages
+   */
+  @DataProvider(name = "responses")
+  public Object[][] createTestParams()
+  {
+    final int expirationTimeSeconds = 123456;
+    final ZonedDateTime exp = ZonedDateTime.now(clock).plusSeconds(expirationTimeSeconds);
+    return
+      new Object[][] {
+        new Object[] {
+          handler,
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS, (ResponseControl) null),
+          null,
+        },
+        new Object[] {
+          handler,
+          createAuthenticationResponse(AuthenticationResultCode.AUTHENTICATION_HANDLER_FAILURE, (ResponseControl) null),
+          null,
+        },
+        new Object[] {
+          handler,
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            new PasswordPolicyControl(PasswordPolicyControl.Error.PASSWORD_EXPIRED)),
+          new PasswordPolicyAccountState(PasswordPolicyControl.Error.PASSWORD_EXPIRED),
+        },
+        new Object[] {
+          handler,
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            new PasswordPolicyControl(-1, 5)),
+          new PasswordPolicyAccountState(5),
+        },
+        new Object[] {
+          handler,
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            new PasswordPolicyControl(-1, 5, PasswordPolicyControl.Error.PASSWORD_EXPIRED)),
+          new PasswordPolicyAccountState(5, PasswordPolicyControl.Error.PASSWORD_EXPIRED),
+        },
+        new Object[] {
+          handler,
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            new PasswordPolicyControl(expirationTimeSeconds, -1)),
+          new PasswordPolicyAccountState(exp),
+        },
+        new Object[] {
+          handler,
+          createAuthenticationResponse(
+            AuthenticationResultCode.AUTHENTICATION_HANDLER_SUCCESS,
+            new PasswordPolicyControl(expirationTimeSeconds, -1, PasswordPolicyControl.Error.PASSWORD_EXPIRED)),
+          new PasswordPolicyAccountState(exp, PasswordPolicyControl.Error.PASSWORD_EXPIRED),
+        },
+      };
+  }
+}

--- a/core/src/test/java/org/ldaptive/control/PasswordPolicyControlTest.java
+++ b/core/src/test/java/org/ldaptive/control/PasswordPolicyControlTest.java
@@ -42,6 +42,10 @@ public class PasswordPolicyControlTest
     final PasswordPolicyControl accountLocked = new PasswordPolicyControl();
     accountLocked.setError(PasswordPolicyControl.Error.ACCOUNT_LOCKED);
 
+    final PasswordPolicyControl changeAfterReset = new PasswordPolicyControl();
+    changeAfterReset.setTimeBeforeExpiration(2513067);
+    changeAfterReset.setError(PasswordPolicyControl.Error.CHANGE_AFTER_RESET);
+
     return
       new Object[][] {
         // timeBeforeExpiration is set
@@ -73,6 +77,13 @@ public class PasswordPolicyControlTest
         new Object[] {
           new DefaultDERBuffer(new byte[] {0x30, 0x03, (byte) 0x81, 0x01, 0x01}),
           accountLocked,
+        },
+        // error=changeAfterReset and timeBeforeExpiration is set
+        new Object[] {
+          new DefaultDERBuffer(
+            new byte[] {
+              0x30, 0x0A, (byte) 0xA0, 0x05, (byte) 0x80, 0x03, 0x26, 0x58, (byte) 0xAB, (byte) 0x81, 0x01, 0x02}),
+          changeAfterReset,
         },
         // empty control
         new Object[] {

--- a/core/src/test/java/org/ldaptive/control/PasswordPolicyControlTest.java
+++ b/core/src/test/java/org/ldaptive/control/PasswordPolicyControlTest.java
@@ -24,27 +24,26 @@ public class PasswordPolicyControlTest
   @DataProvider(name = "response")
   public Object[][] createData()
   {
-    final PasswordPolicyControl timeBeforeExp = new PasswordPolicyControl();
-    timeBeforeExp.setTimeBeforeExpiration(2513067);
+    final PasswordPolicyControl timeBeforeExp = new PasswordPolicyControl(
+      PasswordPolicyControl.WarningType.TIME_BEFORE_EXPIRATION, 2513067);
 
-    final PasswordPolicyControl timeBeforeExpZero = new PasswordPolicyControl();
-    timeBeforeExpZero.setTimeBeforeExpiration(0);
+    final PasswordPolicyControl timeBeforeExpZero = new PasswordPolicyControl(
+      PasswordPolicyControl.WarningType.TIME_BEFORE_EXPIRATION, 0);
 
-    final PasswordPolicyControl graceAuthns = new PasswordPolicyControl();
-    graceAuthns.setGraceAuthNsRemaining(4);
+    final PasswordPolicyControl graceAuthns = new PasswordPolicyControl(
+      PasswordPolicyControl.WarningType.GRACE_AUTHNS_REMAINING, 4);
 
-    final PasswordPolicyControl graceAuthnsZero = new PasswordPolicyControl();
-    graceAuthnsZero.setGraceAuthNsRemaining(0);
+    final PasswordPolicyControl graceAuthnsZero = new PasswordPolicyControl(
+      PasswordPolicyControl.WarningType.GRACE_AUTHNS_REMAINING, 0);
 
-    final PasswordPolicyControl passExpired = new PasswordPolicyControl();
-    passExpired.setError(PasswordPolicyControl.Error.PASSWORD_EXPIRED);
+    final PasswordPolicyControl passExpired = new PasswordPolicyControl(PasswordPolicyControl.Error.PASSWORD_EXPIRED);
 
-    final PasswordPolicyControl accountLocked = new PasswordPolicyControl();
-    accountLocked.setError(PasswordPolicyControl.Error.ACCOUNT_LOCKED);
+    final PasswordPolicyControl accountLocked = new PasswordPolicyControl(PasswordPolicyControl.Error.ACCOUNT_LOCKED);
 
-    final PasswordPolicyControl changeAfterReset = new PasswordPolicyControl();
-    changeAfterReset.setTimeBeforeExpiration(2513067);
-    changeAfterReset.setError(PasswordPolicyControl.Error.CHANGE_AFTER_RESET);
+    final PasswordPolicyControl changeAfterReset = new PasswordPolicyControl(
+      PasswordPolicyControl.WarningType.TIME_BEFORE_EXPIRATION,
+      2513067,
+      PasswordPolicyControl.Error.CHANGE_AFTER_RESET);
 
     return
       new Object[][] {

--- a/integration/src/test/java/org/ldaptive/auth/AuthenticatorTest.java
+++ b/integration/src/test/java/org/ldaptive/auth/AuthenticatorTest.java
@@ -1274,8 +1274,7 @@ public class AuthenticatorTest extends AbstractTest
 
     assertThat(ppcResponse.getError()).isNull();
     assertThat(response.getAccountState()).isNull();
-    assertThat(ppcResponse.getGraceAuthNsRemaining()).isEqualTo(-1);
-    assertThat(ppcResponse.getTimeBeforeExpiration()).isEqualTo(-1);
+    assertThat(ppcResponse.getWarning()).isNull();
 
     final ModifyOperation modify = new ModifyOperation(cf);
     final ModifyResponse modifyResponse = modify.execute(
@@ -1293,8 +1292,7 @@ public class AuthenticatorTest extends AbstractTest
     ppcResponse = (PasswordPolicyControl) response.getControl(PasswordPolicyControl.OID);
     assertThat(ppcResponse.getError()).isNull();
     assertThat(response.getAccountState()).isNull();
-    assertThat(ppcResponse.getTimeBeforeExpiration()).isEqualTo(-1);
-    assertThat(ppcResponse.getGraceAuthNsRemaining()).isEqualTo(-1);
+    assertThat(ppcResponse.getWarning()).isNull();
 
     // test bind with expiration time
     final String newCredential = credential + "-new";
@@ -1312,8 +1310,8 @@ public class AuthenticatorTest extends AbstractTest
     }
     assertThat(response.isSuccess()).isTrue();
     ppcResponse = (PasswordPolicyControl) response.getControl(PasswordPolicyControl.OID);
-    assertThat(ppcResponse.getTimeBeforeExpiration() > 0).isTrue();
-    assertThat(ppcResponse.getGraceAuthNsRemaining()).isEqualTo(-1);
+    assertThat(ppcResponse.hasWarning(PasswordPolicyControl.WarningType.TIME_BEFORE_EXPIRATION)).isTrue();
+    assertThat(ppcResponse.getWarning().getValue() > 0).isTrue();
     assertThat(response.getAccountState().getWarning().getExpiration()).isNotNull();
     assertThat(response.getAccountState().getError()).isNull();
 
@@ -1331,8 +1329,7 @@ public class AuthenticatorTest extends AbstractTest
     assertThat(ppcResponse.getError()).isEqualTo(PasswordPolicyControl.Error.ACCOUNT_LOCKED);
     assertThat(response.getAccountState().getError().getCode())
       .isEqualTo(PasswordPolicyControl.Error.ACCOUNT_LOCKED.getCode());
-    assertThat(ppcResponse.getGraceAuthNsRemaining()).isEqualTo(-1);
-    assertThat(ppcResponse.getTimeBeforeExpiration()).isEqualTo(-1);
+    assertThat(ppcResponse.getWarning()).isNull();
 
     modify.execute(
       new ModifyRequest(
@@ -1354,8 +1351,8 @@ public class AuthenticatorTest extends AbstractTest
     do {
       ppcResponse = (PasswordPolicyControl) response.getControl(PasswordPolicyControl.OID);
       assertThat(response.isSuccess()).isTrue();
-      assertThat(ppcResponse.getTimeBeforeExpiration()).isEqualTo(-1);
-      assertThat(ppcResponse.getGraceAuthNsRemaining()).isEqualTo(graceLogins);
+      assertThat(ppcResponse.hasWarning(PasswordPolicyControl.WarningType.GRACE_AUTHNS_REMAINING)).isTrue();
+      assertThat(ppcResponse.getWarning().getValue()).isEqualTo(graceLogins);
       assertThat(response.getAccountState().getWarning().getLoginsRemaining()).isEqualTo(graceLogins);
       assertThat(response.getAccountState().getWarning().getExpiration()).isNull();
       assertThat(response.getAccountState().getError()).isNull();
@@ -1370,8 +1367,7 @@ public class AuthenticatorTest extends AbstractTest
     assertThat(ppcResponse.getError()).isEqualTo(PasswordPolicyControl.Error.PASSWORD_EXPIRED);
     assertThat(response.getAccountState().getError().getCode())
       .isEqualTo(PasswordPolicyControl.Error.PASSWORD_EXPIRED.getCode());
-    assertThat(ppcResponse.getGraceAuthNsRemaining()).isEqualTo(-1);
-    assertThat(ppcResponse.getTimeBeforeExpiration()).isEqualTo(-1);
+    assertThat(ppcResponse.getWarning()).isNull();
 
     modify.execute(
       new ModifyRequest(


### PR DESCRIPTION
This PR provides (2) commits. (don't squash)

1. Change the cardinality of `AccountState` such that both errors and warnings can be set at the same time. While most systems generally don't support reporting on both errors and warnings, the ppolicy control does allow setting both.
2. Update `PasswordPolicyControl` to align with the definitions in the RFC by allowing both a single warning and an error to be set.